### PR TITLE
Auth PURGE requests

### DIFF
--- a/.github/workflows/_github.yml
+++ b/.github/workflows/_github.yml
@@ -47,7 +47,6 @@ jobs:
       - name: "Publish & deploy tag..."
         if: ${{ startsWith(github.ref, 'refs/tags/v') && github.event_name == 'push' }}
         run: |
-          just publish ${{ github.ref_name }}
           just deploy ${{ github.ref_name }}
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}

--- a/.github/workflows/_namespace.yml
+++ b/.github/workflows/_namespace.yml
@@ -49,7 +49,6 @@ jobs:
       - name: "Publish & deploy tag..."
         if: ${{ startsWith(github.ref, 'refs/tags/v') && github.event_name == 'push' }}
         run: |
-          just publish ${{ github.ref_name }}
           just deploy ${{ github.ref_name }}
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pipely™️ - single-purpose, single-tenant CDN
 
-Based on [Varnish Cache](https://varnish-cache.org/releases/index.html) (OSS FTW 💚). This started as the simplest CDN running on [fly.io](https://fly.io/changelog).
+Based on [Varnish Cache](https://varnish-cache.org/releases/index.html) (OSS FTW 💚). This started as the simplest CDN running on [fly.io](https://fly.io/changelog)
 for [changelog.com](https://changelog.com)
 
 You are welcome to fork and build this your own.
@@ -23,10 +23,17 @@ You are welcome to fork and build this your own.
 - ✅ Send Varnish logs to Honeycomb.io - [PR #12](https://github.com/thechangelog/pipely/pull/12)
 - ✅ Enrich Varnish logs with GeoIP data - [PR #13](https://github.com/thechangelog/pipely/pull/13)
 - ✅ Supervisor restarts crashed processes - [PR #14](https://github.com/thechangelog/pipely/pull/14)
-- ☑️ Require auth for `PURGE` requests
+- ✅ Auth `PURGE` requests
 - ☑️ Send logs to S3
 - ☑️ Add redirects from [Fastly VCL](./varnish/changelog.com.vcl)
 - ☑️ All contributors review & clean-up
+  - `just bench-feed-*`
+  - Is the VCL as clean & efficient as it could be?
+  - Does everything work as expected?
+  - Anything that can be removed?
+  - How do we make this friendlier to new users?
+  - What would make this more contribution-friendly?
+  - How easy is this to use as your own deployment?
 - ☑️ Tag & ship `v1.0-rc.1`
 - ☑️ Route 10% of production traffic through `v1.0-rc.1`
 - ☑️ Tag & ship `v1.0-rc.2` (component updates, etc.)
@@ -54,11 +61,9 @@ Available recipes:
     how-many-lines                  # How many lines of Varnish config?
     how-many-lines-raw              # How many lines of Varnish config?
     http-profile url="https://pipedream.changelog.com/" # Observe all HTTP timings - https://blog.cloudflare.com/a-question-of-timing
-    shell                           # Open an interactive shell for high-level commands, e.g. `test`, `debug | terminal`, etc.
     test                            # Test everything
-    test-acceptance-fastly *ARGS    # Test remote CDN
-    test-acceptance-local           # Test local CDN
-    test-acceptance-pipedream *ARGS # Test remote NEW CDN (a.k.a. Pipely, a.k.a. Pipedream)
+    test-acceptance-fastly *ARGS    # Test CURRENT production
+    test-acceptance-local           # Test local setup
     test-reports                    # Open test reports
     test-reports-rm                 # Clear test reports
     test-vtc                        # Test VCL config
@@ -77,6 +82,7 @@ Available recipes:
     secrets                         # Set app secrets - assumes envrc-secrets was already run
     status                          # Show app status
     tag tag sha discussion          # Tag a new release
+    test-acceptance-pipedream *ARGS # Test NEW production - Pipedream, the Changelog variant of Pipely
 
 # Run the tests
 just test

--- a/container.justfile
+++ b/container.justfile
@@ -46,6 +46,7 @@ test-acceptance-local *ARGS:
      --variable assets_host=cdn2.changelog.com \
      --variable delay_ms=6000 \
      --variable delay_s=5 \
+     --variable purge_token=${PURGE_TOKEN:-""} \
      {{ ARGS }} \
      test/acceptance/*.hurl test/acceptance/pipedream/*.hurl
 
@@ -53,33 +54,42 @@ test-acceptance-local *ARGS:
 cache:
     varnishncsa -c -f '%m %u %h %{x-cache}o %{x-cache-hits}o'
 
-# Benchmark $url as http version $http with $reqs across $conns
+[private]
 bench url="http://localhost:9000/" http="2" reqs="1000" conns="50":
     time oha -n {{ reqs }} -c {{ conns }} {{ url }} --http-version={{ http }}
 
+# Benchmark app origin
+bench-app-1-origin: (bench "https://changelog-2025-05-05.fly.dev/")
+
+# Benchmark app Fastly
+bench-app-2-fastly: (bench "https://changelog.com/" "2" "10000")
+
+# Benchmark app Bunny
+bench-app-3-bunny: (bench "https://bunny.changelog.com/")
+
+# Benchmark app Pipedream
+bench-app-4-pipedream: (bench "https://pipedream.changelog.com/" "2" "10000")
+
 # Benchmark app via local Varnish
-bench-app: (bench "http://localhost:9000/" "2" "200000")
+bench-app-5-local: (bench "http://localhost:9000/" "2" "10000")
 
 # Benchmark app TLS proxy
-bench-app-tls-proxy: (bench "http://localhost:5000/" "1.1")
+bench-app-6-tls-proxy: (bench "http://localhost:5000/" "1.1")
 
-# Benchmark app origin
-bench-app-origin: (bench "https://changelog-2025-05-05.fly.dev/")
+# Benchmark feed origin
+bench-feed-1-origin: (bench "https://feeds.changelog.place/podcast.xml")
 
-# Benchmark feeds via local Varnish
-bench-feeds: (bench "http://localhost:9000/podcast/feed" "2" "200000" "50")
+# Benchmark feed Fastly
+bench-feed-2-fastly: (bench "https://changelog.com/podcast/feed")
 
-# Benchmark feeds TLS proxy
-bench-feeds-tls-proxy: (bench "http://localhost:5010/podcast.xml" "1.1")
+# Benchmark feed Bunny CDN
+bench-feed-3-bunny: (bench "https://bunny.changelog.com/podcast/feed")
 
-# Benchmark feeds origin
-bench-feeds-origin: (bench "https://feeds.changelog.place/podcast.xml")
+# Benchmark feed Pipedream
+bench-feed-4-pipedream: (bench "https://pipedream.changelog.com/podcast/feed")
 
-# Benchmark Fastly
-bench-cdn: (bench "https://changelog.com/podcast/feed")
+# Benchmark feed via local Varnish
+bench-feed-5-local: (bench "http://localhost:9000/podcast/feed" "2" "10000" "50")
 
-# Benchmark Bunny CDN
-bench-bunny: (bench "https://bunny.changelog.com/podcast/feed")
-
-# Benchmark Pipedream
-bench-pipedream: (bench "https://pipedream.changelog.com/podcast/feed")
+# Benchmark feed TLS proxy
+bench-feed-6-tls-proxy: (bench "http://localhost:5010/podcast.xml" "1.1")

--- a/just/dagger.just
+++ b/just/dagger.just
@@ -1,7 +1,7 @@
 # https://github.com/dagger/dagger/releases
 
 [private]
-DAGGER_VERSION := "0.18.9"
+DAGGER_VERSION := "0.18.12"
 [private]
 DAGGER_DIR := BIN_PATH / "dagger-" + DAGGER_VERSION
 [private]

--- a/test/acceptance/pipedream/assets.hurl
+++ b/test/acceptance/pipedream/assets.hurl
@@ -1,5 +1,5 @@
 # Get a static asset
-GET {{host}}/friends/73-pipely-tech.jpg
+GET {{host}}/friends/73-pipely-tech.jpg?hurl=true
 Host: {{assets_host}}
 Content-Type: image/jpeg # expect JPG
 HTTP 200 # expect OK response
@@ -9,15 +9,16 @@ header "via" matches /[vV]arnish/ # served via Varnish
 header "age" exists # cache age works
 
 # Purge the static asset
-PURGE {{host}}/friends/73-pipely-tech.jpg
+PURGE {{host}}/friends/73-pipely-tech.jpg?purge=true
 Host: {{assets_host}}
+Purge-Token: {{purge_token}}
 HTTP 200 # expect OK response
 [Asserts]
-header "cf-ray" not exists # NOT served from Cloudflare
-header "server" == "Varnish" # served by Varnish
+header "x-varnish" exists # served by Varnish
+header "cache-status" contains "synth" # synthetic response
 
 # Get the static asset after PURGE
-GET {{host}}/friends/73-pipely-tech.jpg
+GET {{host}}/friends/73-pipely-tech.jpg?purge=true
 Host: {{assets_host}}
 Content-Type: image/jpeg # expect JPG
 HTTP 200 # expect OK response

--- a/test/acceptance/pipedream/feed.hurl
+++ b/test/acceptance/pipedream/feed.hurl
@@ -1,5 +1,5 @@
 # Get the changelog feed
-GET {{host}}/podcast/feed
+GET {{host}}/podcast/feed?hurl=true
 HTTP 200 # expect OK response
 [Asserts]
 duration < 1000 # ensure that it loads sub 1s when cache is cold...
@@ -12,7 +12,7 @@ header "cache-status" contains "ttl=" # ttl is set
 header "cache-status" contains "grace=" # grace is set
 
 # Get the changelog feed AGAIN
-GET {{host}}/podcast/feed
+GET {{host}}/podcast/feed?hurl=true
 [Options]
 delay: {{delay_ms}} # wait more than TTL so that it becomes stale
 HTTP 200 # expect OK response
@@ -20,10 +20,10 @@ HTTP 200 # expect OK response
 duration < 500 # ensure that it loads sub 500ms when cached...
 header "cache-status" contains "hit" # served from cache
 header "cache-status" contains "stale" # will need to be refreshed from origin
-header "age" toInt > {{delay_s}} # has been stored in cache for MORE than TTL
+header "age" toInt >= {{delay_s}} # has been stored in cache for MORE than TTL
 
 # Get the changelog feed ONE MORE TIME
-GET {{host}}/podcast/feed
+GET {{host}}/podcast/feed?hurl=true
 [Options]
 delay: 5s # wait a bit so that it refreshes from origin
 HTTP 200 # expect OK response
@@ -31,19 +31,19 @@ HTTP 200 # expect OK response
 duration < 500 # ensure that it loads sub 500ms when cached...
 header "cache-status" contains "hit" # served from cache
 header "cache-status" not contains "stale" # not stale
-header "age" toInt < {{delay_s}} # has been stored in cache LESS than TTL
+header "age" toInt <= {{delay_s}} # has been stored in cache LESS than TTL
 
 # Purge the changelog feed
-PURGE {{host}}/podcast/feed
+PURGE {{host}}/podcast/feed?hurl=true
+Purge-Token: {{purge_token}}
 HTTP 200 # expect OK response
 [Asserts]
-header "cf-ray" not exists # NOT served from Cloudflare
-header "server" == "Varnish" # served by Varnish
+header "x-varnish" exists # served by Varnish
+header "cache-status" contains "synth" # synthetic response
 
 # Get the changelog feed after PURGE
-GET {{host}}/podcast/feed
+GET {{host}}/podcast/feed?hurl=true
 HTTP 200 # expect OK response
 [Asserts]
-header "cf-ray" exists # served from Cloudflare
 header "via" matches /[vV]arnish/ # served via Varnish
 header "cache-status" contains "miss" # fresh after purge

--- a/test/acceptance/pipedream/homepage.hurl
+++ b/test/acceptance/pipedream/homepage.hurl
@@ -1,5 +1,5 @@
 # Get the homepage
-GET {{host}}
+GET {{host}}?hurl=true
 HTTP 200 # expect OK response
 [Asserts]
 duration < 500 # ensure that it loads sub 500ms when cache is cold...
@@ -12,7 +12,7 @@ header "cache-status" contains "ttl=" # ttl is set
 header "cache-status" contains "grace=" # grace is set
 
 # Get the homepage AGAIN
-GET {{host}}
+GET {{host}}?hurl=true
 HTTP 200 # expect OK response
 [Asserts]
 duration < 100 # ensure that it loads sub 100ms when cached...
@@ -21,14 +21,16 @@ header "via" matches /[vV]arnish/ # served via Varnish
 header "cache-status" contains "hit" # definitely served from cache
 
 # Purge the homepage
-PURGE {{host}}
+PURGE {{host}}?purge=true
+Purge-Token: {{purge_token}}
 HTTP 200 # expect OK response
 [Asserts]
-header "fly-request-id" not exists # NOT served by Fly
-header "server" == "Varnish" # served by Varnish
+header "x-varnish" exists # served by Varnish
+header "cache-status" contains "synth" # synthetic response
 
 # Get the homepage after PURGE
-GET {{host}}
+GET {{host}}?purge=true
+Purge-Token: {{purge_token}}
 HTTP 200 # expect OK response
 [Asserts]
 header "fly-request-id" exists # served by Fly

--- a/test/vtc/feeds.vtc
+++ b/test/vtc/feeds.vtc
@@ -8,7 +8,17 @@ server s1 {
 
 # Feeds mock server with responses for all feed requests
 server s2 {
-  # Test for /podcast/feed
+# Test for /podcast/feed
+  rxreq
+  expect req.url == "/podcast.xml"
+  txresp -status 200 -body "podcast.xml"
+
+  # Test for /podcast/feed/
+  rxreq
+  expect req.url == "/podcast.xml"
+  txresp -status 200 -body "podcast.xml"
+
+  # Test for /podcast/feed?arg=first&arg=second
   rxreq
   expect req.url == "/podcast.xml"
   txresp -status 200 -body "podcast.xml"
@@ -18,7 +28,27 @@ server s2 {
   expect req.url == "/gotime.xml"
   txresp -status 200 -body "gotime.xml"
 
+  # Test for /gotime/feed/
+  rxreq
+  expect req.url == "/gotime.xml"
+  txresp -status 200 -body "gotime.xml"
+
+  # Test for /gotime/feed?arg=first&arg=second
+  rxreq
+  expect req.url == "/gotime.xml"
+  txresp -status 200 -body "gotime.xml"
+
   # Test for /master/feed
+  rxreq
+  expect req.url == "/master.xml"
+  txresp -status 200 -body "master.xml"
+
+  # Test for /master/feed/
+  rxreq
+  expect req.url == "/master.xml"
+  txresp -status 200 -body "master.xml"
+
+  # Test for /master/feed?arg=first&arg=second
   rxreq
   expect req.url == "/master.xml"
   txresp -status 200 -body "master.xml"
@@ -28,7 +58,27 @@ server s2 {
   expect req.url == "/feed.xml"
   txresp -status 200 -body "feed.xml"
 
+  # Test for /feed/
+  rxreq
+  expect req.url == "/feed.xml"
+  txresp -status 200 -body "feed.xml"
+
+  # Test for /feed?arg=first&arg=second
+  rxreq
+  expect req.url == "/feed.xml"
+  txresp -status 200 -body "feed.xml"
+
   # Test for /jsparty/feed
+  rxreq
+  expect req.url == "/jsparty.xml"
+  txresp -status 200 -body "jsparty.xml"
+
+  # Test for /jsparty/feed/
+  rxreq
+  expect req.url == "/jsparty.xml"
+  txresp -status 200 -body "jsparty.xml"
+
+  # Test for /jsparty/feed?arg=first&arg=second
   rxreq
   expect req.url == "/jsparty.xml"
   txresp -status 200 -body "jsparty.xml"
@@ -38,7 +88,27 @@ server s2 {
   expect req.url == "/shipit.xml"
   txresp -status 200 -body "shipit.xml"
 
+  # Test for /shipit/feed/
+  rxreq
+  expect req.url == "/shipit.xml"
+  txresp -status 200 -body "shipit.xml"
+
+  # Test for /shipit/feed?arg=first&arg=second
+  rxreq
+  expect req.url == "/shipit.xml"
+  txresp -status 200 -body "shipit.xml"
+
   # Test for /news/feed
+  rxreq
+  expect req.url == "/news.xml"
+  txresp -status 200 -body "news.xml"
+
+  # Test for /news/feed/
+  rxreq
+  expect req.url == "/news.xml"
+  txresp -status 200 -body "news.xml"
+
+  # Test for /news/feed?arg=first&arg=second
   rxreq
   expect req.url == "/news.xml"
   txresp -status 200 -body "news.xml"
@@ -48,7 +118,27 @@ server s2 {
   expect req.url == "/brainscience.xml"
   txresp -status 200 -body "brainscience.xml"
 
+  # Test for /brainscience/feed/
+  rxreq
+  expect req.url == "/brainscience.xml"
+  txresp -status 200 -body "brainscience.xml"
+
+  # Test for /brainscience/feed?arg=first&arg=second
+  rxreq
+  expect req.url == "/brainscience.xml"
+  txresp -status 200 -body "brainscience.xml"
+
   # Test for /founderstalk/feed
+  rxreq
+  expect req.url == "/founderstalk.xml"
+  txresp -status 200 -body "founderstalk.xml"
+
+  # Test for /founderstalk/feed/
+  rxreq
+  expect req.url == "/founderstalk.xml"
+  txresp -status 200 -body "founderstalk.xml"
+
+  # Test for /founderstalk/feed?arg=first&arg=second
   rxreq
   expect req.url == "/founderstalk.xml"
   txresp -status 200 -body "founderstalk.xml"
@@ -58,17 +148,42 @@ server s2 {
   expect req.url == "/interviews.xml"
   txresp -status 200 -body "interviews.xml"
 
+  # Test for /interviews/feed/
+  rxreq
+  expect req.url == "/interviews.xml"
+  txresp -status 200 -body "interviews.xml"
+
+  # Test for /interviews/feed?arg=first&arg=second
+  rxreq
+  expect req.url == "/interviews.xml"
+  txresp -status 200 -body "interviews.xml"
+
   # Test for /friends/feed
   rxreq
   expect req.url == "/friends.xml"
   txresp -status 200 -body "friends.xml"
 
-  # Test for /feed/
+  # Test for /friends/feed/
   rxreq
-  expect req.url == "/feed.xml"
-  txresp -status 200 -body "feed.xml"
+  expect req.url == "/friends.xml"
+  txresp -status 200 -body "friends.xml"
+
+  # Test for /friends/feed?arg=first&arg=second
+  rxreq
+  expect req.url == "/friends.xml"
+  txresp -status 200 -body "friends.xml"
 
   # Test for /rfc/feed
+  rxreq
+  expect req.url == "/rfc.xml"
+  txresp -status 200 -body "rfc.xml"
+
+  # Test for /rfc/feed/
+  rxreq
+  expect req.url == "/rfc.xml"
+  txresp -status 200 -body "rfc.xml"
+
+  # Test for /rfc/feed?arg=first&arg=second
   rxreq
   expect req.url == "/rfc.xml"
   txresp -status 200 -body "rfc.xml"
@@ -78,7 +193,27 @@ server s2 {
   expect req.url == "/spotlight.xml"
   txresp -status 200 -body "spotlight.xml"
 
+  # Test for /spotlight/feed/
+  rxreq
+  expect req.url == "/spotlight.xml"
+  txresp -status 200 -body "spotlight.xml"
+
+  # Test for /spotlight/feed?arg=first&arg=second
+  rxreq
+  expect req.url == "/spotlight.xml"
+  txresp -status 200 -body "spotlight.xml"
+
   # Test for /afk/feed
+  rxreq
+  expect req.url == "/afk.xml"
+  txresp -status 200 -body "afk.xml"
+
+  # Test for /afk/feed/
+  rxreq
+  expect req.url == "/afk.xml"
+  txresp -status 200 -body "afk.xml"
+
+  # Test for /afk/feed?arg=first&arg=second
   rxreq
   expect req.url == "/afk.xml"
   txresp -status 200 -body "afk.xml"
@@ -88,7 +223,27 @@ server s2 {
   expect req.url == "/posts.xml"
   txresp -status 200 -body "posts.xml"
 
+  # Test for /posts/feed/
+  rxreq
+  expect req.url == "/posts.xml"
+  txresp -status 200 -body "posts.xml"
+
+  # Test for /posts/feed?arg=first&arg=second
+  rxreq
+  expect req.url == "/posts.xml"
+  txresp -status 200 -body "posts.xml"
+
   # Test for /plusplus/xae9heiphohtupha1Ahha3aexoo0oo4W/feed
+  rxreq
+  expect req.url == "/plusplus.xml"
+  txresp -status 200 -body "plusplus.xml"
+
+  # Test for /plusplus/xae9heiphohtupha1Ahha3aexoo0oo4W/feed/
+  rxreq
+  expect req.url == "/plusplus.xml"
+  txresp -status 200 -body "plusplus.xml"
+
+  # Test for /plusplus/xae9heiphohtupha1Ahha3aexoo0oo4W/feed?arg=first&arg=second
   rxreq
   expect req.url == "/plusplus.xml"
   txresp -status 200 -body "plusplus.xml"
@@ -98,7 +253,22 @@ server s2 {
   expect req.url == "/feed.xml"
   txresp -status 200 -body "feed.xml"
 
+  # Test for /rss/
+  rxreq
+  expect req.url == "/feed.xml"
+  txresp -status 200 -body "feed.xml"
+
+  # Test for /rss?arg=first&arg=second
+  rxreq
+  expect req.url == "/feed.xml"
+  txresp -status 200 -body "feed.xml"
+
   # Test for /feeds/* path
+  rxreq
+  expect req.url == "/feeds/0284CC5C777C51D158BBECCBBB56422A.xml"
+  txresp -status 200 -body "0284CC5C777C51D158BBECCBBB56422A.xml"
+
+  # Test for /feeds/*?arg=first&arg=second path
   rxreq
   expect req.url == "/feeds/0284CC5C777C51D158BBECCBBB56422A.xml"
   txresp -status 200 -body "0284CC5C777C51D158BBECCBBB56422A.xml"
@@ -123,82 +293,60 @@ varnish v1 -vcl {
   sub vcl_recv {
     set req.http.x-backend = "app";
 
-    if (req.url == "/podcast/feed") {
+    if (req.url ~ "^/podcast/feed/?(\?.*)?$") {
       set req.http.x-backend = "feeds";
       set req.url = "/podcast.xml";
-      return(hash);
-    } else if (req.url == "/gotime/feed") {
+    } else if (req.url ~ "^/gotime/feed/?(\?.*)?$") {
       set req.http.x-backend = "feeds";
       set req.url = "/gotime.xml";
-      return(hash);
-    } else if (req.url == "/master/feed") {
+    } else if (req.url ~ "^/master/feed/?(\?.*)?$") {
       set req.http.x-backend = "feeds";
       set req.url = "/master.xml";
-      return(hash);
-    } else if (req.url == "/feed") {
+    } else if (req.url ~ "^/feed/?(\?.*)?$") {
       set req.http.x-backend = "feeds";
       set req.url = "/feed.xml";
-      return(hash);
-    } else if (req.url == "/jsparty/feed") {
+    } else if (req.url ~ "^/jsparty/feed/?(\?.*)?$") {
       set req.http.x-backend = "feeds";
       set req.url = "/jsparty.xml";
-      return(hash);
-    } else if (req.url == "/shipit/feed") {
+    } else if (req.url ~ "^/shipit/feed/?(\?.*)?$") {
       set req.http.x-backend = "feeds";
       set req.url = "/shipit.xml";
-      return(hash);
-    } else if (req.url == "/news/feed") {
+    } else if (req.url ~ "^/news/feed/?(\?.*)?$") {
       set req.http.x-backend = "feeds";
       set req.url = "/news.xml";
-      return(hash);
-    } else if (req.url == "/brainscience/feed") {
+    } else if (req.url ~ "^/brainscience/feed/?(\?.*)?$") {
       set req.http.x-backend = "feeds";
       set req.url = "/brainscience.xml";
-      return(hash);
-    } else if (req.url == "/founderstalk/feed") {
+    } else if (req.url ~ "^/founderstalk/feed/?(\?.*)?$") {
       set req.http.x-backend = "feeds";
       set req.url = "/founderstalk.xml";
-      return(hash);
-    } else if (req.url == "/interviews/feed") {
+    } else if (req.url ~ "^/interviews/feed/?(\?.*)?$") {
       set req.http.x-backend = "feeds";
       set req.url = "/interviews.xml";
-      return(hash);
-    } else if (req.url == "/friends/feed") {
+    } else if (req.url ~ "^/friends/feed/?(\?.*)?$") {
       set req.http.x-backend = "feeds";
       set req.url = "/friends.xml";
-      return(hash);
-    } else if (req.url == "/feed/") {
-      set req.http.x-backend = "feeds";
-      set req.url = "/feed.xml";
-      return(hash);
-    } else if (req.url == "/rfc/feed") {
+    } else if (req.url ~ "^/rfc/feed/?(\?.*)?$") {
       set req.http.x-backend = "feeds";
       set req.url = "/rfc.xml";
-      return(hash);
-    } else if (req.url == "/spotlight/feed") {
+    } else if (req.url ~ "^/spotlight/feed/?(\?.*)?$") {
       set req.http.x-backend = "feeds";
       set req.url = "/spotlight.xml";
-      return(hash);
-    } else if (req.url == "/afk/feed") {
+    } else if (req.url ~ "^/afk/feed/?(\?.*)?$") {
       set req.http.x-backend = "feeds";
       set req.url = "/afk.xml";
-      return(hash);
-    } else if (req.url == "/posts/feed") {
+    } else if (req.url ~ "^/posts/feed/?(\?.*)?$") {
       set req.http.x-backend = "feeds";
       set req.url = "/posts.xml";
-      return(hash);
-    } else if (req.url == "/plusplus/xae9heiphohtupha1Ahha3aexoo0oo4W/feed") {
+    } else if (req.url ~ "^/plusplus/xae9heiphohtupha1Ahha3aexoo0oo4W/feed/?(\?.*)?$") {
       set req.http.x-backend = "feeds";
       set req.url = "/plusplus.xml";
-      return(hash);
-    } else if (req.url == "/rss") {
+    } else if (req.url ~ "^/rss/?(\?.*)?$") {
       set req.http.x-backend = "feeds";
       set req.url = "/feed.xml";
-      return(hash);
-    } else if (req.url ~ "^/feeds/") {
+    } else if (req.url ~ "^/feeds/.*(\?.*)?$") {
       set req.http.x-backend = "feeds";
-      set req.url = req.url + ".xml";
-      return(hash);
+      set req.url = regsub(req.url, "^(/feeds/[^?]*)(\?.*)?$", "\1.xml");
     }
   }
 
@@ -234,145 +382,417 @@ client c2 {
   expect resp.body == "podcast.xml"
 } -run
 
-# /gotime/feed should go to feeds backend
+# /podcast/feed/ should go to feeds backend
 client c3 {
+  txreq -url "/podcast/feed/"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "podcast.xml"
+} -run
+
+# /podcast/feed?arg=first&arg=second should go to feeds backend
+client c4 {
+  txreq -url "/podcast/feed?arg=first&arg=second"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "podcast.xml"
+} -run
+
+# /gotime/feed should go to feeds backend
+client c5 {
   txreq -url "/gotime/feed"
   rxresp
   expect resp.status == 200
   expect resp.body == "gotime.xml"
 } -run
 
+# /gotime/feed/ should go to feeds backend
+client c6 {
+  txreq -url "/gotime/feed/"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "gotime.xml"
+} -run
+
+# /gotime/feed?arg=first&arg=second should go to feeds backend
+client c7 {
+  txreq -url "/gotime/feed?arg=first&arg=second"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "gotime.xml"
+} -run
+
 # /master/feed should go to feeds backend
-client c4 {
+client c8 {
   txreq -url "/master/feed"
   rxresp
   expect resp.status == 200
   expect resp.body == "master.xml"
 } -run
 
+# /master/feed/ should go to feeds backend
+client c9 {
+  txreq -url "/master/feed/"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "master.xml"
+} -run
+
+# /master/feed?arg=first&arg=second should go to feeds backend
+client c10 {
+  txreq -url "/master/feed?arg=first&arg=second"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "master.xml"
+} -run
+
 # /feed should go to feeds backend
-client c5 {
+client c11 {
   txreq -url "/feed"
   rxresp
   expect resp.status == 200
   expect resp.body == "feed.xml"
 } -run
 
-# /jsparty/feed should go to feeds backend
-client c6 {
-  txreq -url "/jsparty/feed"
-  rxresp
-  expect resp.status == 200
-  expect resp.body == "jsparty.xml"
-} -run
-
-# /shipit/feed should go to feeds backend
-client c7 {
-  txreq -url "/shipit/feed"
-  rxresp
-  expect resp.status == 200
-  expect resp.body == "shipit.xml"
-} -run
-
-# /news/feed should go to feeds backend
-client c8 {
-  txreq -url "/news/feed"
-  rxresp
-  expect resp.status == 200
-  expect resp.body == "news.xml"
-} -run
-
-# /brainscience/feed should go to feeds backend
-client c9 {
-  txreq -url "/brainscience/feed"
-  rxresp
-  expect resp.status == 200
-  expect resp.body == "brainscience.xml"
-} -run
-
-# /founderstalk/feed should go to feeds backend
-client c10 {
-  txreq -url "/founderstalk/feed"
-  rxresp
-  expect resp.status == 200
-  expect resp.body == "founderstalk.xml"
-} -run
-
-# /interviews/feed should go to feeds backend
-client c11 {
-  txreq -url "/interviews/feed"
-  rxresp
-  expect resp.status == 200
-  expect resp.body == "interviews.xml"
-} -run
-
-# /friends/feed should go to feeds backend
-client c12 {
-  txreq -url "/friends/feed"
-  rxresp
-  expect resp.status == 200
-  expect resp.body == "friends.xml"
-} -run
-
 # /feed/ should go to feeds backend
-client c13 {
+client c12 {
   txreq -url "/feed/"
   rxresp
   expect resp.status == 200
   expect resp.body == "feed.xml"
 } -run
 
-# /rfc/feed should go to feeds backend
+# /feed?arg=first&arg=second should go to feeds backend
+client c13 {
+  txreq -url "/feed?arg=first&arg=second"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "feed.xml"
+} -run
+
+# /jsparty/feed should go to feeds backend
 client c14 {
+  txreq -url "/jsparty/feed"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "jsparty.xml"
+} -run
+
+# /jsparty/feed/ should go to feeds backend
+client c15 {
+  txreq -url "/jsparty/feed/"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "jsparty.xml"
+} -run
+
+# /jsparty/feed?arg=first&arg=second should go to feeds backend
+client c16 {
+  txreq -url "/jsparty/feed?arg=first&arg=second"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "jsparty.xml"
+} -run
+
+# /shipit/feed should go to feeds backend
+client c17 {
+  txreq -url "/shipit/feed"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "shipit.xml"
+} -run
+
+# /shipit/feed/ should go to feeds backend
+client c18 {
+  txreq -url "/shipit/feed/"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "shipit.xml"
+} -run
+
+# /shipit/feed?arg=first&arg=second should go to feeds backend
+client c19 {
+  txreq -url "/shipit/feed?arg=first&arg=second"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "shipit.xml"
+} -run
+
+# /news/feed should go to feeds backend
+client c20 {
+  txreq -url "/news/feed"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "news.xml"
+} -run
+
+# /news/feed/ should go to feeds backend
+client c21 {
+  txreq -url "/news/feed/"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "news.xml"
+} -run
+
+# /news/feed?arg=first&arg=second should go to feeds backend
+client c22 {
+  txreq -url "/news/feed?arg=first&arg=second"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "news.xml"
+} -run
+
+# /brainscience/feed should go to feeds backend
+client c23 {
+  txreq -url "/brainscience/feed"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "brainscience.xml"
+} -run
+
+# /brainscience/feed/ should go to feeds backend
+client c24 {
+  txreq -url "/brainscience/feed/"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "brainscience.xml"
+} -run
+
+# /brainscience/feed?arg=first&arg=second should go to feeds backend
+client c25 {
+  txreq -url "/brainscience/feed?arg=first&arg=second"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "brainscience.xml"
+} -run
+
+# /founderstalk/feed should go to feeds backend
+client c26 {
+  txreq -url "/founderstalk/feed"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "founderstalk.xml"
+} -run
+
+# /founderstalk/feed/ should go to feeds backend
+client c27 {
+  txreq -url "/founderstalk/feed/"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "founderstalk.xml"
+} -run
+
+# /founderstalk/feed?arg=first&arg=second should go to feeds backend
+client c28 {
+  txreq -url "/founderstalk/feed?arg=first&arg=second"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "founderstalk.xml"
+} -run
+
+# /interviews/feed should go to feeds backend
+client c29 {
+  txreq -url "/interviews/feed"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "interviews.xml"
+} -run
+
+# /interviews/feed/ should go to feeds backend
+client c30 {
+  txreq -url "/interviews/feed/"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "interviews.xml"
+} -run
+
+# /interviews/feed?arg=first&arg=second should go to feeds backend
+client c31 {
+  txreq -url "/interviews/feed?arg=first&arg=second"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "interviews.xml"
+} -run
+
+# /friends/feed should go to feeds backend
+client c32 {
+  txreq -url "/friends/feed"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "friends.xml"
+} -run
+
+# /friends/feed/ should go to feeds backend
+client c33 {
+  txreq -url "/friends/feed/"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "friends.xml"
+} -run
+
+# /friends/feed?arg=first&arg=second should go to feeds backend
+client c34 {
+  txreq -url "/friends/feed?arg=first&arg=second"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "friends.xml"
+} -run
+
+# /rfc/feed should go to feeds backend
+client c35 {
   txreq -url "/rfc/feed"
   rxresp
   expect resp.status == 200
   expect resp.body == "rfc.xml"
 } -run
 
+# /rfc/feed/ should go to feeds backend
+client c36 {
+  txreq -url "/rfc/feed/"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "rfc.xml"
+} -run
+
+# /rfc/feed?arg=first&arg=second should go to feeds backend
+client c37 {
+  txreq -url "/rfc/feed?arg=first&arg=second"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "rfc.xml"
+} -run
+
 # /spotlight/feed should go to feeds backend
-client c15 {
+client c38 {
   txreq -url "/spotlight/feed"
   rxresp
   expect resp.status == 200
   expect resp.body == "spotlight.xml"
 } -run
 
+# /spotlight/feed/ should go to feeds backend
+client c39 {
+  txreq -url "/spotlight/feed/"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "spotlight.xml"
+} -run
+
+# /spotlight/feed?arg=first&arg=second should go to feeds backend
+client c40 {
+  txreq -url "/spotlight/feed?arg=first&arg=second"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "spotlight.xml"
+} -run
+
 # /afk/feed should go to feeds backend
-client c16 {
+client c41 {
   txreq -url "/afk/feed"
   rxresp
   expect resp.status == 200
   expect resp.body == "afk.xml"
 } -run
 
+# /afk/feed/ should go to feeds backend
+client c42 {
+  txreq -url "/afk/feed/"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "afk.xml"
+} -run
+
+# /afk/feed?arg=first&arg=second should go to feeds backend
+client c43 {
+  txreq -url "/afk/feed?arg=first&arg=second"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "afk.xml"
+} -run
+
 # /posts/feed should go to feeds backend
-client c17 {
+client c44 {
   txreq -url "/posts/feed"
   rxresp
   expect resp.status == 200
   expect resp.body == "posts.xml"
 } -run
 
+# /posts/feed/ should go to feeds backend
+client c45 {
+  txreq -url "/posts/feed/"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "posts.xml"
+} -run
+
+# /posts/feed?arg=first&arg=second should go to feeds backend
+client c46 {
+  txreq -url "/posts/feed?arg=first&arg=second"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "posts.xml"
+} -run
+
 # /plusplus/xae9heiphohtupha1Ahha3aexoo0oo4W/feed should go to feeds backend
-client c18 {
+client c47 {
   txreq -url "/plusplus/xae9heiphohtupha1Ahha3aexoo0oo4W/feed"
   rxresp
   expect resp.status == 200
   expect resp.body == "plusplus.xml"
 } -run
 
+# /plusplus/xae9heiphohtupha1Ahha3aexoo0oo4W/feed/ should go to feeds backend
+client c48 {
+  txreq -url "/plusplus/xae9heiphohtupha1Ahha3aexoo0oo4W/feed/"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "plusplus.xml"
+} -run
+
+# /plusplus/xae9heiphohtupha1Ahha3aexoo0oo4W/feed?arg=first&arg=second should go to feeds backend
+client c49 {
+  txreq -url "/plusplus/xae9heiphohtupha1Ahha3aexoo0oo4W/feed?arg=first&arg=second"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "plusplus.xml"
+} -run
+
 # /rss should go to feeds backend
-client c18 {
+client c50 {
   txreq -url "/rss"
   rxresp
   expect resp.status == 200
   expect resp.body == "feed.xml"
 } -run
 
+# /rss/ should go to feeds backend
+client c51 {
+  txreq -url "/rss/"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "feed.xml"
+} -run
+
+# /rss?arg=first&arg=second should go to feeds backend
+client c52 {
+  txreq -url "/rss?arg=first&arg=second"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "feed.xml"
+} -run
+
 # /feeds/* should go to feeds backend
-client c19 {
+client c53 {
   txreq -url "/feeds/0284CC5C777C51D158BBECCBBB56422A"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "0284CC5C777C51D158BBECCBBB56422A.xml"
+} -run
+
+# /feeds/*?arg=first&arg=second should go to feeds backend
+client c54 {
+  txreq -url "/feeds/0284CC5C777C51D158BBECCBBB56422A?arg=first&arg=second"
   rxresp
   expect resp.status == 200
   expect resp.body == "0284CC5C777C51D158BBECCBBB56422A.xml"

--- a/test/vtc/purge.vtc
+++ b/test/vtc/purge.vtc
@@ -7,16 +7,35 @@ server s1 {
 
 varnish v1 -vcl+backend {
   sub vcl_recv {
-      # https://varnish-cache.org/docs/7.7/users-guide/purging.html
-      if (req.method == "PURGE") {
-        return (purge);
+    if (req.method == "PURGE") {
+      if (req.http.purge-token == "doit") {
+        return(purge);
+      } else {
+        return(synth(401, "Invalid PURGE token"));
       }
+    }
   }
 } -start
 
-# Test 1: Test PURGE method
+# PURGE with no token
 client c1 {
   txreq -method PURGE -url "/"
+  rxresp
+  expect resp.status == 401
+  expect resp.body ~ "Invalid PURGE token"
+} -run
+
+# PURGE with invalid token
+client c2 {
+  txreq -method PURGE -url "/" -hdr "purge-token: do"
+  rxresp
+  expect resp.status == 401
+  expect resp.body ~ "Invalid PURGE token"
+} -run
+
+# PURGE with correct token
+client c3 {
+  txreq -method PURGE -url "/" -hdr "purge-token: doit"
   rxresp
   expect resp.status == 200
 } -run

--- a/varnish/pipedream.changelog.com.vcl
+++ b/varnish/pipedream.changelog.com.vcl
@@ -142,69 +142,71 @@ sub vcl_recv {
   # TODO: Upload feed.json too?
   #
   # FWIW 🤦 https://github.com/varnishcache/varnish-cache/issues/2355
-  if (req.url == "/podcast/feed") {
+  if (req.url ~ "^/podcast/feed/?(\?.*)?$") {
     set req.http.x-backend = "feeds";
     set req.url = "/podcast.xml";
-  } else if (req.url == "/gotime/feed") {
+  } else if (req.url ~ "^/gotime/feed/?(\?.*)?$") {
     set req.http.x-backend = "feeds";
     set req.url = "/gotime.xml";
-  } else if (req.url == "/master/feed") {
+  } else if (req.url ~ "^/master/feed/?(\?.*)?$") {
     set req.http.x-backend = "feeds";
     set req.url = "/master.xml";
-  } else if (req.url == "/feed") {
+  } else if (req.url ~ "^/feed/?(\?.*)?$") {
     set req.http.x-backend = "feeds";
     set req.url = "/feed.xml";
-  } else if (req.url == "/jsparty/feed") {
+  } else if (req.url ~ "^/jsparty/feed/?(\?.*)?$") {
     set req.http.x-backend = "feeds";
     set req.url = "/jsparty.xml";
-  } else if (req.url == "/shipit/feed") {
+  } else if (req.url ~ "^/shipit/feed/?(\?.*)?$") {
     set req.http.x-backend = "feeds";
     set req.url = "/shipit.xml";
-  } else if (req.url == "/news/feed") {
+  } else if (req.url ~ "^/news/feed/?(\?.*)?$") {
     set req.http.x-backend = "feeds";
     set req.url = "/news.xml";
-  } else if (req.url == "/brainscience/feed") {
+  } else if (req.url ~ "^/brainscience/feed/?(\?.*)?$") {
     set req.http.x-backend = "feeds";
     set req.url = "/brainscience.xml";
-  } else if (req.url == "/founderstalk/feed") {
+  } else if (req.url ~ "^/founderstalk/feed/?(\?.*)?$") {
     set req.http.x-backend = "feeds";
     set req.url = "/founderstalk.xml";
-  } else if (req.url == "/interviews/feed") {
+  } else if (req.url ~ "^/interviews/feed/?(\?.*)?$") {
     set req.http.x-backend = "feeds";
     set req.url = "/interviews.xml";
-  } else if (req.url == "/friends/feed") {
+  } else if (req.url ~ "^/friends/feed/?(\?.*)?$") {
     set req.http.x-backend = "feeds";
     set req.url = "/friends.xml";
-  } else if (req.url == "/feed/") {
-    set req.http.x-backend = "feeds";
-    set req.url = "/feed.xml";
-  } else if (req.url == "/rfc/feed") {
+  } else if (req.url ~ "^/rfc/feed/?(\?.*)?$") {
     set req.http.x-backend = "feeds";
     set req.url = "/rfc.xml";
-  } else if (req.url == "/spotlight/feed") {
+  } else if (req.url ~ "^/spotlight/feed/?(\?.*)?$") {
     set req.http.x-backend = "feeds";
     set req.url = "/spotlight.xml";
-  } else if (req.url == "/afk/feed") {
+  } else if (req.url ~ "^/afk/feed/?(\?.*)?$") {
     set req.http.x-backend = "feeds";
     set req.url = "/afk.xml";
-  } else if (req.url == "/posts/feed") {
+  } else if (req.url ~ "^/posts/feed/?(\?.*)?$") {
     set req.http.x-backend = "feeds";
     set req.url = "/posts.xml";
-  } else if (req.url == "/plusplus/xae9heiphohtupha1Ahha3aexoo0oo4W/feed") {
+  } else if (req.url ~ "^/plusplus/xae9heiphohtupha1Ahha3aexoo0oo4W/feed/?(\?.*)?$") {
     set req.http.x-backend = "feeds";
     set req.url = "/plusplus.xml";
-  } else if (req.url == "/rss") {
+  } else if (req.url ~ "^/rss/?(\?.*)?$") {
     set req.http.x-backend = "feeds";
     set req.url = "/feed.xml";
-  } else if (req.url ~ "^/feeds/") {
+  } else if (req.url ~ "^/feeds/.*(\?.*)?$") {
     set req.http.x-backend = "feeds";
-    set req.url = req.url + ".xml";
+    set req.url = regsub(req.url, "^(/feeds/[^?]*)(\?.*)?$", "\1.xml");
   }
 
   ### PURGE
   # https://varnish-cache.org/docs/7.7/users-guide/purging.html
   if (req.method == "PURGE") {
-    return(purge);
+    # If no token token is configured allow un-authenticated PURGEs, otherwise require it.
+    if (std.getenv("PURGE_TOKEN") == "" || req.http.purge-token == std.getenv("PURGE_TOKEN")) {
+      return(purge);
+    } else {
+      return(synth(401, "Invalid PURGE token"));
+    }
   }
 }
 


### PR DESCRIPTION
So that we don't allow anyone to PURGE URLs. `purge-token` request header is required if the instance has been configured with `PURGE_TOKEN` secret (exposed as an environment variable).

A few other improvements:
- add `PURGE` VTC & acceptance tests
- handle URL parameters for all feed redirects
- add extra tests to cover feed URL variations
- wrap long commands in the `justfile` so that they are easier to read
- separate the benchmark just commands into app & feed (inside the debug container) & capture the intended run order
- add a few ideas for all contributors review
- upgrade Dagger to v0.18.12 (latest release)

Required by:
- https://github.com/thechangelog/changelog.com/pull/549

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - PURGE requests now require a valid token for authorization, enhancing security.
  - Feed URLs support optional trailing slashes and query parameters for improved flexibility.

- **Bug Fixes**
  - Acceptance tests and VCL logic updated to handle PURGE requests with tokens and to test feed URL variants.
  - Acceptance tests refined with query parameters and authorization headers for more precise validation.

- **Documentation**
  - README improved for clarity, detailed checklists, and revised command descriptions.

- **Chores**
  - Workflow steps streamlined by removing redundant publish commands.
  - Benchmarking and acceptance test commands reorganized and clarified for consistency.
  - Command targets enhanced with explicit environment variable handling and secure credential management.
  - Updated dependency versions and container image digests for improved reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->