### PR TITLE
Fix test-acceptance-pipedream in CI

### DIFF
--- a/.github/workflows/_github.yml
+++ b/.github/workflows/_github.yml
@@ -35,6 +35,7 @@ jobs:
           just test-acceptance-pipedream
         env:
           TERM: xterm
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           DAGGER_CLOUD_TOKEN: ${{ secrets.DAGGER_CLOUD_TOKEN }}
 
       - name: "Archive test acceptance reports..."
@@ -47,6 +48,7 @@ jobs:
       - name: "Publish & deploy tag..."
         if: ${{ startsWith(github.ref, 'refs/tags/v') && github.event_name == 'push' }}
         run: |
+          just publish ${{ github.ref_name }}
           just deploy ${{ github.ref_name }}
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}

--- a/.github/workflows/_namespace.yml
+++ b/.github/workflows/_namespace.yml
@@ -37,6 +37,7 @@ jobs:
           just test-acceptance-pipedream
         env:
           TERM: xterm
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           DAGGER_CLOUD_TOKEN: ${{ secrets.DAGGER_CLOUD_TOKEN }}
 
       - name: "Archive test acceptance reports..."
@@ -49,6 +50,7 @@ jobs:
       - name: "Publish & deploy tag..."
         if: ${{ startsWith(github.ref, 'refs/tags/v') && github.event_name == 'push' }}
         run: |
+          just publish ${{ github.ref_name }}
           just deploy ${{ github.ref_name }}
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}

--- a/just/_config.just
+++ b/just/_config.just
@@ -8,6 +8,12 @@ OS := if os() == "macos" { "apple" } else { "unknown" }
 OS_ALT := if os() == "macos" { "darwin" } else { "linux-gnu" }
 
 [private]
+OS_ALT2 := if os() == "macos" { "darwin" } else { "linux" }
+
+[private]
+ARCH_ALT := if arch() == "x86_64" { "amd64" } else { "arm64" }
+
+[private]
 LOCAL_PATH := home_dir() / ".local"
 
 [private]

--- a/just/op.just
+++ b/just/op.just
@@ -1,0 +1,23 @@
+# https://app-updates.agilebits.com/product_history/CLI2
+
+[private]
+OP_VERSION := "2.31.1"
+[private]
+OP_NAME := "op_" + OS_ALT2 + "_" + ARCH_ALT + "_v" + OP_VERSION
+[private]
+OP_DIR := LOCAL_PATH / OP_NAME / "bin"
+[private]
+OP := OP_DIR / "op"
+
+[private]
+[positional-arguments]
+op *ARGS:
+  @[ -x {{ OP }} ] \
+  || (echo {{ _GREEN }}🔐 Installing op {{ OP_VERSION }} ...{{ _RESET }} \
+     && mkdir -p {{ BIN_PATH }} {{ OP_DIR }} \
+     && curl -LSsfo {{ OP_NAME }}.zip "https://cache.agilebits.com/dist/1P/op2/pkg/v{{ OP_VERSION }}/{{ OP_NAME }}.zip" \
+     && unzip {{ OP_NAME }}.zip -d {{ OP_DIR }} \
+     && rm {{ OP_NAME }}.zip \
+     && chmod +x {{ OP }} && echo {{ _MAGENTA }}{{ OP }} {{ _RESET }} && {{ OP }} --version \
+     && ln -sf {{ OP }} {{ BIN_PATH }}/op && echo {{ _MAGENTA }}op{{ _RESET }} && op --version)
+  {{ if ARGS != "" { OP + " " + ' "$@"' } else { OP + " --help" } }}


### PR DESCRIPTION
These were failing because the CI didn't have the `op` CLI installed. While it's worth notifying in Zulip when tests on `main` fail, let's circle back to it after RC.1 is out.

## 🤦‍♂️
![image](https://github.com/user-attachments/assets/f3359d54-8881-465e-abde-ffef89215dec)

## 🤦‍♂️🤦‍♂️
![image](https://github.com/user-attachments/assets/c6773c58-9959-4adb-bfa9-11baab64004c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated installation and execution support for the 1Password CLI tool, allowing seamless use within command recipes.

* **Chores**
  * Updated configuration to support alternative OS and architecture naming conventions.
  * Modified command recipes to route 1Password CLI usage through the unified command infrastructure for improved consistency.
  * Enhanced CI workflows to include a new service account token for improved authentication during acceptance tests.
  * Increased wait times in machine restart procedures for improved stability.
  * Simplified deployment image argument handling in command recipes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->