### PR TITLE
Send Varnish logs to AWS S3

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -4,3 +4,9 @@ export OP_ACCOUNT=changelog.1password.com
 # Load secrets if configured - only available to changelog.com team members:
 # https://github.com/orgs/thechangelog/people
 source_env_if_exists .envrc.secrets
+
+# Defining env vars which are changelog.com specific
+# Will need refactoring post 1.0
+export AWS_REGION="eu-west-1"
+export AWS_S3_BUCKET_SUFFIX="-local-pipedream"
+export HONEYCOMB_DATASET="pipedream-dev"

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Pipely™️ - single-purpose, single-tenant CDN
 
-Based on [Varnish Cache](https://varnish-cache.org/releases/index.html) (OSS FTW 💚). This started as the simplest CDN running on [fly.io](https://fly.io/changelog)
+Based on [Varnish Cache](https://varnish-cache.org/releases/index.html). This started as the simplest CDN running on [fly.io](https://fly.io/changelog)
 for [changelog.com](https://changelog.com)
 
-You are welcome to fork and build this your own.
+You are welcome to fork this and build your own - OSS FTW 💚
 
 ## How it started
 
@@ -11,7 +11,7 @@ You are welcome to fork and build this your own.
 
 > 🧢 Jerod Santo - March 29, 2024 - <a href="https://changelog.com/friends/38#transcript-208" target="_blank">Changelog & Friends #38</a>
 
-## How is it going - a.k.a. The Roadmap to `v1.0`
+## How it's going - a.k.a. roadmap to `v1.0`
 
 - ✅ Static backend, 1 day stale, stale on error, `x`-headers - [Initial commit](https://github.com/thechangelog/pipely/commit/17d3899a52d9dc887efd7f49de92b24249431234)
 - ✅ Dynamic backend, `cache-status` header - [PR #1](https://github.com/thechangelog/pipely/pull/1)
@@ -24,9 +24,9 @@ You are welcome to fork and build this your own.
 - ✅ Enrich Varnish logs with GeoIP data - [PR #13](https://github.com/thechangelog/pipely/pull/13)
 - ✅ Supervisor restarts crashed processes - [PR #14](https://github.com/thechangelog/pipely/pull/14)
 - ✅ Auth `PURGE` requests - [PR #16](https://github.com/thechangelog/pipely/pull/16)
-- ☑️ Send logs to S3
 - ✅ Add redirects from [Fastly VCL](./varnish/changelog.com.vcl) - [PR #19](https://github.com/thechangelog/pipely/pull/19)
-- ☑️ All contributors review & clean-up
+- ✅ Send Varnish logs to S3 - [PR #27](https://github.com/thechangelog/pipely/pull/27)
+- ✅ All contributors review & clean-up
   - Is the VCL as clean & efficient as it could be?
   - Does everything work as expected?
   - Anything that can be removed?
@@ -42,32 +42,28 @@ You are welcome to fork and build this your own.
 - ☑️ Route 33% of production traffic through `v1.0-rc.2` (observe cold cache behaviour, etc.)
 - ☑️ Tag & ship `v1.0-rc.3` (component updates, etc.)
 - ☑️ Route 80% of production traffic through `v1.0-rc.3` (last chance to kick the tyres before `1.0`)
-- ☑️ Tag & ship `v1.0`
+- ☑️ Tag & ship `v1.0` during [changelog.com/live](https://changelog.com/live)
 - ☑️ Route 100% of production traffic through `v1.0`
 
-## What next?
+## Post `v1.0`
 
 - Refactor VCL to use `include`
   - This will enable us to do reuse the same configs in the tests [💪 @mttjohnson](https://cdn2.changelog.com/uploads/podcast/news-2023-04-03/the-changelog-news-2023-04-03.mp3)
 
 ## Local development and testing
 
+While it's fun watching other people experiment with digital resin (varnish 😂), it's a whole lot more fun when you can repeat those experiments yourself, understand more how it works, and make your own modifications.
+
 ### Prerequisites
 
-- Docker or equivalent
-- Just version 1.27.0 or higher
+- 🐳 [Docker](https://docs.docker.com/engine/install/)
+- 🤖 [Just](https://github.com/casey/just?tab=readme-ov-file#installation) version `1.27.0` or higher
 
 And that's about it. Everything else is containerized with Dagger.
 
-**For Windows Developers:**
-
-The project's toolchain is made for Linux-like systems. On a Windows machine you will need to have the Windows Subsystem for Linux (WSL) installed in addition to Docker. `Just` should be installed inside your WSL Linux operating system. You might be able to run Just natively from Windows, but there are some known bugs related to home directory filenames, so better to avoid that altogether and work directly in WSL.
-
-While it's fun watching other people experiment with digital resin (varnish
-😂), it's a whole lot more fun when you can repeat those experiments yourself,
-understand more how it works, and make your own modifications.
-
-Use 🤖 [`just`](https://github.com/casey/just?tab=readme-ov-file#installation) `v1.27.0` or newer as the starting point:
+> [!NOTE]
+>  **For Windows Developers:**
+> The project's toolchain is made for Linux-like systems. On a Windows machine you will need to have the Windows Subsystem for Linux (WSL) installed in addition to Docker. `just` should be installed inside your WSL Linux operating system. You might be able to run Just natively from Windows, but there are some known bugs related to home directory filenames, so better to avoid that altogether and work directly in WSL.
 
 ```bash
 just
@@ -85,13 +81,14 @@ Available recipes:
     test-vtc                        # Test VCL config
 
     [team]
-    cert fqdn                       # Add cert $fqdn to app
+    cert fqdn                       # Show cert $fqdn for app
+    cert-add fqdn                   # Add cert $fqdn to app
     certs                           # Show app certs
     deploy tag=_DEFAULT_TAG         # Deploy container image
     envrc-secrets                   # Create .envrc.secrets with credentials from 1Password
     ips                             # Show app IPs
-    local-production-debug          # Debug production container locally - assumes envrc-secrets has already run
-    local-production-run            # Run production container locally - assumes envrc-secrets has already run - available on http://localhost:9000
+    local-debug-production          # Debug production container locally - assumes envrc-secrets has already run
+    local-run-production            # Run production container locally - assumes envrc-secrets has already run - available on http://localhost:9000
     machines                        # Show app machines
     publish tag=_DEFAULT_TAG        # Publish container image - assumes envrc-secrets was already run
     restart                         # Restart ALL app machines, one-by-one
@@ -105,8 +102,6 @@ Available recipes:
 just test
 ```
 
-The only other pre-requisite for the commands that run services locally is 🐳 [Docker](https://docs.docker.com/engine/install/)
-
 ## How can you help
 
 If you have any ideas on how to improve this, please open an issue or go
@@ -115,7 +110,7 @@ straight for a pull request. We make this as easy as possible:
 - This repository is kept small & simple (single purpose: build the simplest CDN on Fly.io)
 - Slow & thoughtful approach - join our journey via [audio with transcripts](https://changelog.com/topic/kaizen) or [written](https://github.com/thechangelog/changelog.com/discussions/categories/kaizen)
 
-See you in our [Zulip Chat](https://changelog.zulipchat.com/) 👋
+See you in our [Zulip Chat](https://changelog.zulipchat.com/#narrow/channel/513743-pipely) 👋
 
 > [!NOTE]
 > Join from <https://changelog.com/~> . It requires signing up and requesting an invite before you can **Log in**

--- a/envrc.secrets.op
+++ b/envrc.secrets.op
@@ -1,2 +1,9 @@
 # This token gets us access to all others
 export OP_SERVICE_ACCOUNT_TOKEN="op://pipely/op/credential"
+# Working around: an internal error occurred, please contact 1Password at support@1password.com or https://developer.1password.com/joinslack: invalid client id
+export PURGE_TOKEN="op://pipely/purge/credential"
+export HONEYCOMB_API_KEY="op://pipely/honeycomb/credential"
+export AWS_ACCESS_KEY_ID="op://pipely/aws-s3-logs/access-key-id"
+export AWS_SECRET_ACCESS_KEY="op://pipely/aws-s3-logs/secret-access-key"
+export MAXMIND_AUTH="op://pipely/maxmind/credential"
+export GCHR_PASS="op://pipely/ghcr/credential"

--- a/just/dagger.just
+++ b/just/dagger.just
@@ -1,7 +1,7 @@
 # https://github.com/dagger/dagger/releases
 
 [private]
-DAGGER_VERSION := "0.18.12"
+DAGGER_VERSION := "0.18.14"
 [private]
 DAGGER_DIR := BIN_PATH / "pipely-dagger-" + DAGGER_VERSION
 [private]

--- a/vector/pipedream.changelog.com/debug_s3.yaml
+++ b/vector/pipedream.changelog.com/debug_s3.yaml
@@ -1,8 +1,9 @@
 sinks:
   # https://vector.dev/docs/reference/configuration/sinks/console/
-  debug_varnish:
+  debug_s3:
     type: "console"
     encoding:
       codec: "logfmt"
     inputs:
-      - "varnish"
+      - "s3_csv"
+      - "s3_json_feeds"

--- a/vector/pipedream.changelog.com/debug_varnish_geoip.yaml
+++ b/vector/pipedream.changelog.com/debug_varnish_geoip.yaml
@@ -1,7 +1,8 @@
 sinks:
+  # https://vector.dev/docs/reference/configuration/sinks/console/
   debug_varnish_geoip:
     type: "console"
     encoding:
-      codec: "json"
+      codec: "logfmt"
     inputs:
       - "varnish_geoip"

--- a/vector/pipedream.changelog.com/geoip.yaml
+++ b/vector/pipedream.changelog.com/geoip.yaml
@@ -1,19 +1,214 @@
 enrichment_tables:
+  # https://vector.dev/docs/reference/configuration/#enrichment-tables
   geoip:
     type: "mmdb"
     path: "/usr/local/share/GeoIP/GeoLite2-City.mmdb"
 
 transforms:
   varnish_geoip:
+    # https://vector.dev/docs/reference/configuration/transforms/remap/
     type: "remap"
     inputs:
       - "varnish"
     source: |
+      .transform = "varnish_geoip"
       geoip_data, err = get_enrichment_table_record("geoip", {"ip": .client_ip})
       if err == null {
         .geo_city = geoip_data.city.names.en
         .geo_country_code = geoip_data.country.iso_code
+        .geo_country_name = geoip_data.country.names.en
+        .geo_continent_code = geoip_data.continent.code
+        .geo_latitude = geoip_data.location.latitude
+        .geo_longitude = geoip_data.location.longitude
       }
+
+  s3_json_feeds:
+    # https://vector.dev/docs/reference/configuration/transforms/remap/
+    type: "remap"
+    inputs:
+      - "varnish_geoip"
+    source: |
+      .transform = "s3_json_feeds"
+      url_string = string!(.url) || ""
+      url_parts = parse_url!("http://for.vector.parse-url.local" + url_string)
+      url_parts.path = string!(url_parts.path)
+      if starts_with(url_parts.path, "/feeds/") || ends_with(url_parts.path, "/feed") {
+        .message = {
+          "timestamp": parse_timestamp!(.time, format: "%Y-%m-%dT%H:%M:%SZ"),
+          "client_ip": .client_ip,
+          "geo_country": downcase!(.geo_country_name || ""),
+          "geo_city": downcase!(.geo_city || ""),
+          "host": .host,
+          "url": .url,
+          "request_method": .request,
+          "request_protocol": .protocol,
+          "request_referer": .request_referer,
+          "request_user_agent": .request_user_agent,
+          "response_state": .cache_status,
+          "response_status": .status,
+          "response_reason": "",
+          "response_body_size": .resp_body_size,
+          "server_datacenter": .server_datacenter
+        }
+      } else {
+        abort
+      }
+
+  s3_csv:
+    # https://vector.dev/docs/reference/configuration/transforms/remap/
+    type: "remap"
+    inputs:
+      - "varnish_geoip"
+    source: |
+      .transform = "s3_csv"
+      formatted_time = format_timestamp!(now(), "%d/%b/%Y:%H:%M:%S %z")
+      parsed_time, err = parse_timestamp(.time, "%+")
+      if err == null {
+        formatted_time = format_timestamp!(parsed_time, "%d/%b/%Y:%H:%M:%S %z")
+      }
+      .formatted_time = "[" + formatted_time + "]"
+      .geo_city = downcase!(.geo_city || "")
+      .geo_country_name = downcase!(.geo_country_name || "")
+
+  s3_csv_changelog:
+    # https://vector.dev/docs/reference/configuration/transforms/filter/
+    type: "filter"
+    inputs:
+      - "s3_csv"
+    condition:
+      type: "vrl"
+      source: |
+        starts_with(string!(.url), "/uploads/podcast/")
+
+  s3_csv_gotime:
+    # https://vector.dev/docs/reference/configuration/transforms/filter/
+    type: "filter"
+    inputs:
+      - "s3_csv"
+    condition:
+      type: "vrl"
+      source: |
+        starts_with(string!(.url), "/uploads/gotime/")
+
+  s3_csv_rfc:
+    # https://vector.dev/docs/reference/configuration/transforms/filter/
+    type: "filter"
+    inputs:
+      - "s3_csv"
+    condition:
+      type: "vrl"
+      source: |
+        starts_with(string!(.url), "/uploads/rfc/")
+
+  s3_csv_founderstalk:
+    # https://vector.dev/docs/reference/configuration/transforms/filter/
+    type: "filter"
+    inputs:
+      - "s3_csv"
+    condition:
+      type: "vrl"
+      source: |
+        starts_with(string!(.url), "/uploads/founderstalk/")
+
+  s3_csv_spotlight:
+    # https://vector.dev/docs/reference/configuration/transforms/filter/
+    type: "filter"
+    inputs:
+      - "s3_csv"
+    condition:
+      type: "vrl"
+      source: |
+        starts_with(string!(.url), "/uploads/spotlight/")
+
+  s3_csv_jsparty:
+    # https://vector.dev/docs/reference/configuration/transforms/filter/
+    type: "filter"
+    inputs:
+      - "s3_csv"
+    condition:
+      type: "vrl"
+      source: |
+        starts_with(string!(.url), "/uploads/jsparty/")
+
+  s3_csv_practicalai:
+    # https://vector.dev/docs/reference/configuration/transforms/filter/
+    type: "filter"
+    inputs:
+      - "s3_csv"
+    condition:
+      type: "vrl"
+      source: |
+        starts_with(string!(.url), "/uploads/practicalai/")
+
+  s3_csv_reactpodcast:
+    # https://vector.dev/docs/reference/configuration/transforms/filter/
+    type: "filter"
+    inputs:
+      - "s3_csv"
+    condition:
+      type: "vrl"
+      source: |
+        starts_with(string!(.url), "/uploads/reactpodcast/")
+
+  s3_csv_afk:
+    # https://vector.dev/docs/reference/configuration/transforms/filter/
+    type: "filter"
+    inputs:
+      - "s3_csv"
+    condition:
+      type: "vrl"
+      source: |
+        starts_with(string!(.url), "/uploads/afk/")
+
+  s3_csv_backstage:
+    # https://vector.dev/docs/reference/configuration/transforms/filter/
+    type: "filter"
+    inputs:
+      - "s3_csv"
+    condition:
+      type: "vrl"
+      source: |
+        starts_with(string!(.url), "/uploads/backstage/")
+
+  s3_csv_brainscience:
+    # https://vector.dev/docs/reference/configuration/transforms/filter/
+    type: "filter"
+    inputs:
+      - "s3_csv"
+    condition:
+      type: "vrl"
+      source: |
+        starts_with(string!(.url), "/uploads/brainscience/")
+
+  s3_csv_shipit:
+    # https://vector.dev/docs/reference/configuration/transforms/filter/
+    type: "filter"
+    inputs:
+      - "s3_csv"
+    condition:
+      type: "vrl"
+      source: |
+        starts_with(string!(.url), "/uploads/shipit/")
+
+  s3_csv_news:
+    # https://vector.dev/docs/reference/configuration/transforms/filter/
+    type: "filter"
+    inputs:
+      - "s3_csv"
+    condition:
+      type: "vrl"
+      source: |
+        starts_with(string!(.url), "/uploads/news/")
+
+  s3_csv_friends:
+    # https://vector.dev/docs/reference/configuration/transforms/filter/
+    type: "filter"
+    inputs:
+      - "s3_csv"
+    condition:
+      type: "vrl"
+      source: |
+        starts_with(string!(.url), "/uploads/friends/")
 
 sinks:
   honeycomb:
@@ -23,3 +218,484 @@ sinks:
       - "varnish_geoip"
     api_key: ${HONEYCOMB_API_KEY:-REMEMBER_TO_SET_THIS_IN_PRODUCTION}
     dataset: ${HONEYCOMB_DATASET:-REMEMBER_TO_SET_THIS_IN_PRODUCTION}
+
+  s3_logs_feeds:
+    # https://vector.dev/docs/reference/configuration/sinks/aws_s3/
+    type: "aws_s3"
+    inputs:
+      - "s3_json_feeds"
+    bucket: "changelog-logs-feeds${S3_BUCKET_SUFFIX:-}"
+    region: ${AWS_REGION:-REMEMBER_TO_SET_THIS_IN_PRODUCTION}
+    key_prefix: "%Y-%m-%dT%H:%M%z-${FLY_REGION:-LOCAL}-"
+    filename_append_uuid: false
+    encoding:
+      codec: "text"
+    compression: "none"
+    batch:
+      max_bytes: 102400 # write to S3 when 100KB worth of events are stored in memory
+      timeout_secs: 60 # write to S3 once per minute if any events in memory (matches the key_prefix)
+    auth:
+      access_key_id: ${AWS_ACCESS_KEY_ID:-REMEMBER_TO_SET_THIS_IN_PRODUCTION}
+      secret_access_key: ${AWS_SECRET_ACCESS_KEY:-REMEMBER_TO_SET_THIS_IN_PRODUCTION}
+
+  s3_logs_changelog:
+    # https://vector.dev/docs/reference/configuration/sinks/aws_s3/
+    type: "aws_s3"
+    inputs:
+      - "s3_csv_changelog"
+    bucket: "changelog-logs-podcast${S3_BUCKET_SUFFIX:-}"
+    region: ${AWS_REGION:-REMEMBER_TO_SET_THIS_IN_PRODUCTION}
+    key_prefix: "%Y-%m-%dT%H:%M%z-${FLY_REGION:-LOCAL}-"
+    filename_append_uuid: false
+    encoding:
+      # https://vector.dev/docs/reference/configuration/sinks/file/#encoding.csv.fields
+      codec: "csv"
+      csv:
+        fields:
+          - client_ip
+          - formatted_time
+          - url
+          - resp_body_size
+          - status
+          - request_user_agent
+          - geo_latitude
+          - geo_longitude
+          - geo_city
+          - geo_continent_code
+          - geo_country_name
+    compression: "none"
+    batch:
+      max_bytes: 102400 # write to S3 when 100KB worth of events are stored in memory
+      timeout_secs: 60 # write to S3 once per minute if any events in memory (matches the key_prefix)
+    auth:
+      access_key_id: ${AWS_ACCESS_KEY_ID:-REMEMBER_TO_SET_THIS_IN_PRODUCTION}
+      secret_access_key: ${AWS_SECRET_ACCESS_KEY:-REMEMBER_TO_SET_THIS_IN_PRODUCTION}
+
+  s3_logs_gotime:
+    # https://vector.dev/docs/reference/configuration/sinks/aws_s3/
+    type: "aws_s3"
+    inputs:
+      - "s3_csv_gotime"
+    bucket: "changelog-logs-gotime${S3_BUCKET_SUFFIX:-}"
+    region: ${AWS_REGION:-REMEMBER_TO_SET_THIS_IN_PRODUCTION}
+    key_prefix: "%Y-%m-%dT%H:%M%z-${FLY_REGION:-LOCAL}-"
+    filename_append_uuid: false
+    encoding:
+      # https://vector.dev/docs/reference/configuration/sinks/file/#encoding.csv.fields
+      codec: "csv"
+      csv:
+        fields:
+          - client_ip
+          - formatted_time
+          - url
+          - resp_body_size
+          - status
+          - request_user_agent
+          - geo_latitude
+          - geo_longitude
+          - geo_city
+          - geo_continent_code
+          - geo_country_name
+    compression: "none"
+    batch:
+      max_bytes: 102400 # write to S3 when 100KB worth of events are stored in memory
+      timeout_secs: 60 # write to S3 once per minute if any events in memory (matches the key_prefix)
+    auth:
+      access_key_id: ${AWS_ACCESS_KEY_ID:-REMEMBER_TO_SET_THIS_IN_PRODUCTION}
+      secret_access_key: ${AWS_SECRET_ACCESS_KEY:-REMEMBER_TO_SET_THIS_IN_PRODUCTION}
+
+  s3_logs_rfc:
+    # https://vector.dev/docs/reference/configuration/sinks/aws_s3/
+    type: "aws_s3"
+    inputs:
+      - "s3_csv_rfc"
+    bucket: "changelog-logs-rfc${S3_BUCKET_SUFFIX:-}"
+    region: ${AWS_REGION:-REMEMBER_TO_SET_THIS_IN_PRODUCTION}
+    key_prefix: "%Y-%m-%dT%H:%M%z-${FLY_REGION:-LOCAL}-"
+    filename_append_uuid: false
+    encoding:
+      # https://vector.dev/docs/reference/configuration/sinks/file/#encoding.csv.fields
+      codec: "csv"
+      csv:
+        fields:
+          - client_ip
+          - formatted_time
+          - url
+          - resp_body_size
+          - status
+          - request_user_agent
+          - geo_latitude
+          - geo_longitude
+          - geo_city
+          - geo_continent_code
+          - geo_country_name
+    compression: "none"
+    batch:
+      max_bytes: 102400 # write to S3 when 100KB worth of events are stored in memory
+      timeout_secs: 60 # write to S3 once per minute if any events in memory (matches the key_prefix)
+    auth:
+      access_key_id: ${AWS_ACCESS_KEY_ID:-REMEMBER_TO_SET_THIS_IN_PRODUCTION}
+      secret_access_key: ${AWS_SECRET_ACCESS_KEY:-REMEMBER_TO_SET_THIS_IN_PRODUCTION}
+
+  s3_logs_founderstalk:
+    # https://vector.dev/docs/reference/configuration/sinks/aws_s3/
+    type: "aws_s3"
+    inputs:
+      - "s3_csv_founderstalk"
+    bucket: "changelog-logs-founderstalk${S3_BUCKET_SUFFIX:-}"
+    region: ${AWS_REGION:-REMEMBER_TO_SET_THIS_IN_PRODUCTION}
+    key_prefix: "%Y-%m-%dT%H:%M%z-${FLY_REGION:-LOCAL}-"
+    filename_append_uuid: false
+    encoding:
+      # https://vector.dev/docs/reference/configuration/sinks/file/#encoding.csv.fields
+      codec: "csv"
+      csv:
+        fields:
+          - client_ip
+          - formatted_time
+          - url
+          - resp_body_size
+          - status
+          - request_user_agent
+          - geo_latitude
+          - geo_longitude
+          - geo_city
+          - geo_continent_code
+          - geo_country_name
+    compression: "none"
+    batch:
+      max_bytes: 102400 # write to S3 when 100KB worth of events are stored in memory
+      timeout_secs: 60 # write to S3 once per minute if any events in memory (matches the key_prefix)
+    auth:
+      access_key_id: ${AWS_ACCESS_KEY_ID:-REMEMBER_TO_SET_THIS_IN_PRODUCTION}
+      secret_access_key: ${AWS_SECRET_ACCESS_KEY:-REMEMBER_TO_SET_THIS_IN_PRODUCTION}
+
+  s3_logs_spotlight:
+    # https://vector.dev/docs/reference/configuration/sinks/aws_s3/
+    type: "aws_s3"
+    inputs:
+      - "s3_csv_spotlight"
+    bucket: "changelog-logs-spotlight${S3_BUCKET_SUFFIX:-}"
+    region: ${AWS_REGION:-REMEMBER_TO_SET_THIS_IN_PRODUCTION}
+    key_prefix: "%Y-%m-%dT%H:%M%z-${FLY_REGION:-LOCAL}-"
+    filename_append_uuid: false
+    encoding:
+      # https://vector.dev/docs/reference/configuration/sinks/file/#encoding.csv.fields
+      codec: "csv"
+      csv:
+        fields:
+          - client_ip
+          - formatted_time
+          - url
+          - resp_body_size
+          - status
+          - request_user_agent
+          - geo_latitude
+          - geo_longitude
+          - geo_city
+          - geo_continent_code
+          - geo_country_name
+    compression: "none"
+    batch:
+      max_bytes: 102400 # write to S3 when 100KB worth of events are stored in memory
+      timeout_secs: 60 # write to S3 once per minute if any events in memory (matches the key_prefix)
+    auth:
+      access_key_id: ${AWS_ACCESS_KEY_ID:-REMEMBER_TO_SET_THIS_IN_PRODUCTION}
+      secret_access_key: ${AWS_SECRET_ACCESS_KEY:-REMEMBER_TO_SET_THIS_IN_PRODUCTION}
+
+  s3_logs_jsparty:
+    # https://vector.dev/docs/reference/configuration/sinks/aws_s3/
+    type: "aws_s3"
+    inputs:
+      - "s3_csv_jsparty"
+    bucket: "changelog-logs-jsparty${S3_BUCKET_SUFFIX:-}"
+    region: ${AWS_REGION:-REMEMBER_TO_SET_THIS_IN_PRODUCTION}
+    key_prefix: "%Y-%m-%dT%H:%M%z-${FLY_REGION:-LOCAL}-"
+    filename_append_uuid: false
+    encoding:
+      # https://vector.dev/docs/reference/configuration/sinks/file/#encoding.csv.fields
+      codec: "csv"
+      csv:
+        fields:
+          - client_ip
+          - formatted_time
+          - url
+          - resp_body_size
+          - status
+          - request_user_agent
+          - geo_latitude
+          - geo_longitude
+          - geo_city
+          - geo_continent_code
+          - geo_country_name
+    compression: "none"
+    batch:
+      max_bytes: 102400 # write to S3 when 100KB worth of events are stored in memory
+      timeout_secs: 60 # write to S3 once per minute if any events in memory (matches the key_prefix)
+    auth:
+      access_key_id: ${AWS_ACCESS_KEY_ID:-REMEMBER_TO_SET_THIS_IN_PRODUCTION}
+      secret_access_key: ${AWS_SECRET_ACCESS_KEY:-REMEMBER_TO_SET_THIS_IN_PRODUCTION}
+
+  s3_logs_practicalai:
+    # https://vector.dev/docs/reference/configuration/sinks/aws_s3/
+    type: "aws_s3"
+    inputs:
+      - "s3_csv_practicalai"
+    bucket: "changelog-logs-practicalai${S3_BUCKET_SUFFIX:-}"
+    region: ${AWS_REGION:-REMEMBER_TO_SET_THIS_IN_PRODUCTION}
+    key_prefix: "%Y-%m-%dT%H:%M%z-${FLY_REGION:-LOCAL}-"
+    filename_append_uuid: false
+    encoding:
+      # https://vector.dev/docs/reference/configuration/sinks/file/#encoding.csv.fields
+      codec: "csv"
+      csv:
+        fields:
+          - client_ip
+          - formatted_time
+          - url
+          - resp_body_size
+          - status
+          - request_user_agent
+          - geo_latitude
+          - geo_longitude
+          - geo_city
+          - geo_continent_code
+          - geo_country_name
+    compression: "none"
+    batch:
+      max_bytes: 102400 # write to S3 when 100KB worth of events are stored in memory
+      timeout_secs: 60 # write to S3 once per minute if any events in memory (matches the key_prefix)
+    auth:
+      access_key_id: ${AWS_ACCESS_KEY_ID:-REMEMBER_TO_SET_THIS_IN_PRODUCTION}
+      secret_access_key: ${AWS_SECRET_ACCESS_KEY:-REMEMBER_TO_SET_THIS_IN_PRODUCTION}
+
+  s3_logs_reactpodcast:
+    # https://vector.dev/docs/reference/configuration/sinks/aws_s3/
+    type: "aws_s3"
+    inputs:
+      - "s3_csv_reactpodcast"
+    bucket: "changelog-logs-reactpodcast${S3_BUCKET_SUFFIX:-}"
+    region: ${AWS_REGION:-REMEMBER_TO_SET_THIS_IN_PRODUCTION}
+    key_prefix: "%Y-%m-%dT%H:%M%z-${FLY_REGION:-LOCAL}-"
+    filename_append_uuid: false
+    encoding:
+      # https://vector.dev/docs/reference/configuration/sinks/file/#encoding.csv.fields
+      codec: "csv"
+      csv:
+        fields:
+          - client_ip
+          - formatted_time
+          - url
+          - resp_body_size
+          - status
+          - request_user_agent
+          - geo_latitude
+          - geo_longitude
+          - geo_city
+          - geo_continent_code
+          - geo_country_name
+    compression: "none"
+    batch:
+      max_bytes: 102400 # write to S3 when 100KB worth of events are stored in memory
+      timeout_secs: 60 # write to S3 once per minute if any events in memory (matches the key_prefix)
+    auth:
+      access_key_id: ${AWS_ACCESS_KEY_ID:-REMEMBER_TO_SET_THIS_IN_PRODUCTION}
+      secret_access_key: ${AWS_SECRET_ACCESS_KEY:-REMEMBER_TO_SET_THIS_IN_PRODUCTION}
+
+  s3_logs_afk:
+    # https://vector.dev/docs/reference/configuration/sinks/aws_s3/
+    type: "aws_s3"
+    inputs:
+      - "s3_csv_afk"
+    bucket: "changelog-logs-afk${S3_BUCKET_SUFFIX:-}"
+    region: ${AWS_REGION:-REMEMBER_TO_SET_THIS_IN_PRODUCTION}
+    key_prefix: "%Y-%m-%dT%H:%M%z-${FLY_REGION:-LOCAL}-"
+    filename_append_uuid: false
+    encoding:
+      # https://vector.dev/docs/reference/configuration/sinks/file/#encoding.csv.fields
+      codec: "csv"
+      csv:
+        fields:
+          - client_ip
+          - formatted_time
+          - url
+          - resp_body_size
+          - status
+          - request_user_agent
+          - geo_latitude
+          - geo_longitude
+          - geo_city
+          - geo_continent_code
+          - geo_country_name
+    compression: "none"
+    batch:
+      max_bytes: 102400 # write to S3 when 100KB worth of events are stored in memory
+      timeout_secs: 60 # write to S3 once per minute if any events in memory (matches the key_prefix)
+    auth:
+      access_key_id: ${AWS_ACCESS_KEY_ID:-REMEMBER_TO_SET_THIS_IN_PRODUCTION}
+      secret_access_key: ${AWS_SECRET_ACCESS_KEY:-REMEMBER_TO_SET_THIS_IN_PRODUCTION}
+
+  s3_logs_backstage:
+    # https://vector.dev/docs/reference/configuration/sinks/aws_s3/
+    type: "aws_s3"
+    inputs:
+      - "s3_csv_backstage"
+    bucket: "changelog-logs-backstage${S3_BUCKET_SUFFIX:-}"
+    region: ${AWS_REGION:-REMEMBER_TO_SET_THIS_IN_PRODUCTION}
+    key_prefix: "%Y-%m-%dT%H:%M%z-${FLY_REGION:-LOCAL}-"
+    filename_append_uuid: false
+    encoding:
+      # https://vector.dev/docs/reference/configuration/sinks/file/#encoding.csv.fields
+      codec: "csv"
+      csv:
+        fields:
+          - client_ip
+          - formatted_time
+          - url
+          - resp_body_size
+          - status
+          - request_user_agent
+          - geo_latitude
+          - geo_longitude
+          - geo_city
+          - geo_continent_code
+          - geo_country_name
+    compression: "none"
+    batch:
+      max_bytes: 102400 # write to S3 when 100KB worth of events are stored in memory
+      timeout_secs: 60 # write to S3 once per minute if any events in memory (matches the key_prefix)
+    auth:
+      access_key_id: ${AWS_ACCESS_KEY_ID:-REMEMBER_TO_SET_THIS_IN_PRODUCTION}
+      secret_access_key: ${AWS_SECRET_ACCESS_KEY:-REMEMBER_TO_SET_THIS_IN_PRODUCTION}
+
+  s3_logs_brainscience:
+    # https://vector.dev/docs/reference/configuration/sinks/aws_s3/
+    type: "aws_s3"
+    inputs:
+      - "s3_csv_brainscience"
+    bucket: "changelog-logs-brainscience${S3_BUCKET_SUFFIX:-}"
+    region: ${AWS_REGION:-REMEMBER_TO_SET_THIS_IN_PRODUCTION}
+    key_prefix: "%Y-%m-%dT%H:%M%z-${FLY_REGION:-LOCAL}-"
+    filename_append_uuid: false
+    encoding:
+      # https://vector.dev/docs/reference/configuration/sinks/file/#encoding.csv.fields
+      codec: "csv"
+      csv:
+        fields:
+          - client_ip
+          - formatted_time
+          - url
+          - resp_body_size
+          - status
+          - request_user_agent
+          - geo_latitude
+          - geo_longitude
+          - geo_city
+          - geo_continent_code
+          - geo_country_name
+    compression: "none"
+    batch:
+      max_bytes: 102400 # write to S3 when 100KB worth of events are stored in memory
+      timeout_secs: 60 # write to S3 once per minute if any events in memory (matches the key_prefix)
+    auth:
+      access_key_id: ${AWS_ACCESS_KEY_ID:-REMEMBER_TO_SET_THIS_IN_PRODUCTION}
+      secret_access_key: ${AWS_SECRET_ACCESS_KEY:-REMEMBER_TO_SET_THIS_IN_PRODUCTION}
+
+  s3_logs_shipit:
+    # https://vector.dev/docs/reference/configuration/sinks/aws_s3/
+    type: "aws_s3"
+    inputs:
+      - "s3_csv_shipit"
+    bucket: "changelog-logs-shipit${S3_BUCKET_SUFFIX:-}"
+    region: ${AWS_REGION:-REMEMBER_TO_SET_THIS_IN_PRODUCTION}
+    key_prefix: "%Y-%m-%dT%H:%M%z-${FLY_REGION:-LOCAL}-"
+    filename_append_uuid: false
+    encoding:
+      # https://vector.dev/docs/reference/configuration/sinks/file/#encoding.csv.fields
+      codec: "csv"
+      csv:
+        fields:
+          - client_ip
+          - formatted_time
+          - url
+          - resp_body_size
+          - status
+          - request_user_agent
+          - geo_latitude
+          - geo_longitude
+          - geo_city
+          - geo_continent_code
+          - geo_country_name
+    compression: "none"
+    batch:
+      max_bytes: 102400 # write to S3 when 100KB worth of events are stored in memory
+      timeout_secs: 60 # write to S3 once per minute if any events in memory (matches the key_prefix)
+    auth:
+      access_key_id: ${AWS_ACCESS_KEY_ID:-REMEMBER_TO_SET_THIS_IN_PRODUCTION}
+      secret_access_key: ${AWS_SECRET_ACCESS_KEY:-REMEMBER_TO_SET_THIS_IN_PRODUCTION}
+
+  s3_logs_news:
+    # https://vector.dev/docs/reference/configuration/sinks/aws_s3/
+    type: "aws_s3"
+    inputs:
+      - "s3_csv_news"
+    bucket: "changelog-logs-news${S3_BUCKET_SUFFIX:-}"
+    region: ${AWS_REGION:-REMEMBER_TO_SET_THIS_IN_PRODUCTION}
+    key_prefix: "%Y-%m-%dT%H:%M%z-${FLY_REGION:-LOCAL}-"
+    filename_append_uuid: false
+    encoding:
+      # https://vector.dev/docs/reference/configuration/sinks/file/#encoding.csv.fields
+      codec: "csv"
+      csv:
+        fields:
+          - client_ip
+          - formatted_time
+          - url
+          - resp_body_size
+          - status
+          - request_user_agent
+          - geo_latitude
+          - geo_longitude
+          - geo_city
+          - geo_continent_code
+          - geo_country_name
+    compression: "none"
+    batch:
+      max_bytes: 102400 # write to S3 when 100KB worth of events are stored in memory
+      timeout_secs: 60 # write to S3 once per minute if any events in memory (matches the key_prefix)
+    auth:
+      access_key_id: ${AWS_ACCESS_KEY_ID:-REMEMBER_TO_SET_THIS_IN_PRODUCTION}
+      secret_access_key: ${AWS_SECRET_ACCESS_KEY:-REMEMBER_TO_SET_THIS_IN_PRODUCTION}
+
+  s3_logs_friends:
+    # https://vector.dev/docs/reference/configuration/sinks/aws_s3/
+    type: "aws_s3"
+    inputs:
+      - "s3_csv_friends"
+    bucket: "changelog-logs-friends${S3_BUCKET_SUFFIX:-}"
+    region: ${AWS_REGION:-REMEMBER_TO_SET_THIS_IN_PRODUCTION}
+    key_prefix: "%Y-%m-%dT%H:%M%z-${FLY_REGION:-LOCAL}-"
+    filename_append_uuid: false
+    encoding:
+      # https://vector.dev/docs/reference/configuration/sinks/file/#encoding.csv.fields
+      codec: "csv"
+      csv:
+        fields:
+          - client_ip
+          - formatted_time
+          - url
+          - resp_body_size
+          - status
+          - request_user_agent
+          - geo_latitude
+          - geo_longitude
+          - geo_city
+          - geo_continent_code
+          - geo_country_name
+    compression: "none"
+    batch:
+      max_bytes: 102400 # write to S3 when 100KB worth of events are stored in memory
+      timeout_secs: 60 # write to S3 once per minute if any events in memory (matches the key_prefix)
+    auth:
+      access_key_id: ${AWS_ACCESS_KEY_ID:-REMEMBER_TO_SET_THIS_IN_PRODUCTION}
+      secret_access_key: ${AWS_SECRET_ACCESS_KEY:-REMEMBER_TO_SET_THIS_IN_PRODUCTION}


### PR DESCRIPTION
Uses the same format as the existing logs. Resisting to improve this was hard, but necessary. We are just lifting & shifting in this phase, will improve in post 1.0 follow-ups.

We are writing the logs to S3 at least (whichever comes first):
- every hour
- when 100KB of logs are stored in memory

<img width="1915" height="849" alt="image" src="https://github.com/user-attachments/assets/28182b30-344b-4f8c-8e37-2ebef54d050a" />

For local production, we are using a different S3 region and suffix the buckets with `-local-pipedream` so that we experience the full end-to-end setup, but make it twice as difficult to write to the production buckets (different region & different bucket name).

While this is OK for now, the improvement that I'm itching to do is replace **ALL** of this with ClickHouse. While S3 makes sense as a data lake, the CSV / JSON combo are showing their age. A much better approach would be to leverage something modern like ClickHouse, and send all requests to it, without making a distinction. This would allow to replace:
- Logging logic in the CDN
- S3 log stats
- Stats workers
- Honeycomb.io

This is something that I'm much more excited about, than working around complexities inherent to the current setup. Something to dig into post 1.0, for sure 😉

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for exporting enriched logs to AWS S3 buckets, filtered by content category and formatted as CSV or JSON.
  * Enhanced log enrichment with additional GeoIP fields: country, continent, latitude, and longitude.
  * Introduced debug configuration for S3 logging and a console sink for combined S3 log output.
  * Added new commands for managing and viewing SSL certificates.
  * Enabled AWS region and credentials configuration for container environments.

* **Improvements**
  * Updated task naming and environment variable sourcing for local debugging and running of production containers.
  * Extended secret management to include AWS credentials.
  * Improved README formatting, clarity, and updated links and checklist statuses.
  * Updated environment variable exports for changelog.com and local development settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->