### PR TITLE
Prepare for 20% of the production traffic

### DIFF
--- a/.github/workflows/_namespace.yml
+++ b/.github/workflows/_namespace.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: extractions/setup-just@v2
         with:
-          just-version: "1.40.0"
+          just-version: "1.42.3"
 
       - name: "Test all (including local acceptance)..."
         run: |

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Pipely™️ - single-purpose, single-tenant CDN
+# Pipely™ - single-purpose, single-tenant CDN
 
 Based on [Varnish Cache](https://varnish-cache.org/releases/index.html). This started as the simplest CDN running on [fly.io](https://fly.io/changelog)
 for [changelog.com](https://changelog.com)
@@ -37,19 +37,18 @@ You are welcome to fork this and build your own - OSS FTW 💚
   - [Add debug welcome message and prompt #25](https://github.com/thechangelog/pipely/pull/25)
   - [Avoid using home_dir() due to Windows issues #26](https://github.com/thechangelog/pipely/pull/26)
   - [Add troubleshooting and misc to local dev docs #29](https://github.com/thechangelog/pipely/pull/29)
-- ✅ Tag & ship `v1.0.0-rc.1`
-- ☑️ Route 10% of production traffic through `v1.0.0-rc.1`
-- ☑️ Tag & ship `v1.0.0-rc.2` (component updates, etc.)
-- ☑️ Route 33% of production traffic through `v1.0.0-rc.2` (observe cold cache behaviour, etc.)
-- ☑️ Tag & ship `v1.0.0-rc.3` (component updates, etc.)
-- ☑️ Route 80% of production traffic through `v1.0.0-rc.3` (last chance to kick the tyres before `1.0`)
-- ☑️ Tag & ship `v1.0.0` during [changelog.com/live](https://changelog.com/live)
-- ☑️ Route 100% of production traffic through `v1.0.0`
+- ✅ Tag & ship `v1.0-rc.1`
+- ✅ Tag & ship `v1.0-rc.2` (component updates, etc.)
+- ☑️ Route 20% of the production traffic through
+- ☑️ Tag & ship `v1.0-rc.3` (component updates, etc.)
+- ☑️ Route 50% of the production traffic through (observe cold cache behaviour, etc.)
+- ☑️ Tag & ship `v1.0` just before [changelog.com/live](https://changelog.com/live)
+- ☑️ Route all the production traffic through `v1.0`
 
 ## Post `v1.0`
 
 - Refactor VCL to use `include`
-  - This will enable us to do reuse the same configs in the tests [💪 @mttjohnson](https://cdn2.changelog.com/uploads/podcast/news-2023-04-03/the-changelog-news-2023-04-03.mp3)
+  - This will enable us to do reuse the same configs in the tests [💪 @mttjohnson](https://github.com/thechangelog/pipely/pull/19#pullrequestreview-3013467499)
 - [Add logging acceptance tests](https://github.com/thechangelog/pipely/pull/27#issuecomment-3094684063)
 - Keep Dagger version in `.github/workflows/_namespace.yaml` in sync with `just/dagger.just`
 

--- a/container/justfile
+++ b/container/justfile
@@ -44,7 +44,7 @@ test-acceptance-local *ARGS:
     hurl --test --color --continue-on-error --report-html /var/opt/hurl/test-acceptance-local \
      --variable proto=http \
      --variable host=localhost:9000 \
-     --variable assets_host=cdn2.changelog.com \
+     --variable assets_host=cdn.changelog.com \
      --variable delay_ms=6000 \
      --variable delay_s=5 \
      --variable purge_token="{{ env("PURGE_TOKEN") }}" \

--- a/dagger/main.go
+++ b/dagger/main.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	// https://hub.docker.com/_/golang/tags?name=1.24
-	golangVersion = "1.24.4@sha256:10c131810f80a4802c49cab0961bbe18a16f4bb2fb99ef16deaa23e4246fc817"
+	golangVersion = "1.24.5@sha256:ef5b4be1f94b36c90385abd9b6b4f201723ae28e71acacb76d00687333c17282"
 
 	// https://github.com/nabsul/tls-exterminator
 	tlsExterminatorVersion = "4226223f2380319e73300bc7d14fd652c56c6b4e"
@@ -68,7 +68,7 @@ func New(
 	tag string,
 
 	// https://hub.docker.com/_/varnish/tags
-	// +default="7.7.1@sha256:18c3eeba5e929068aa46fd1b8de8345dc3c4b488d957a0953fff9916341b4587"
+	// +default="7.7.1@sha256:1a684d37ec7a4f441a36c84945ee7713d1ddd59e8204d4040aeecb529ed4f68e"
 	varnishVersion string,
 
 	// +default=9000
@@ -89,7 +89,7 @@ func New(
 	// +default="5010:feeds.changelog.place:"
 	feedsProxy string,
 
-	// +default="5020:changelog.place:cdn2.changelog.com"
+	// +default="5020:changelog.place:cdn.changelog.com"
 	assetsProxy string,
 
 	// https://ui.honeycomb.io/changelog/datasets/pipely/overview

--- a/justfile
+++ b/justfile
@@ -51,7 +51,7 @@ test-acceptance-pipedream *ARGS:
       just hurl --test --color --report-html tmp/test-acceptance-pipedream --continue-on-error \
         --variable proto=https \
         --variable host=pipedream.changelog.com \
-        --variable assets_host=cdn2.changelog.com \
+        --variable assets_host=cdn.changelog.com \
         --variable delay_ms=65000 \
         --variable delay_s=60 \
         {{ ARGS }} \
@@ -143,11 +143,10 @@ scale:
 [group('team')]
 secrets:
     PURGE_TOKEN="op://pipely/purge/credential" \
-    HONEYCOMB_DATASET="pipedream"
     HONEYCOMB_API_KEY="op://pipely/honeycomb/credential" \
     AWS_ACCESS_KEY_ID="op://pipely/aws-s3-logs/access-key-id" \
     AWS_SECRET_ACCESS_KEY="op://pipely/aws-s3-logs/secret-access-key" \
-    just op run -- bash -c 'flyctl secrets set --stage HONEYCOMB_DATASET="$HONEYCOMB_DATASET" HONEYCOMB_API_KEY="$HONEYCOMB_API_KEY" PURGE_TOKEN="$PURGE_TOKEN" AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY"'
+    just op run -- bash -c 'flyctl secrets set --stage HONEYCOMB_DATASET="pipedream" HONEYCOMB_API_KEY="$HONEYCOMB_API_KEY" PURGE_TOKEN="$PURGE_TOKEN" AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY"'
     flyctl secrets list
 
 # Add cert $fqdn to app


### PR DESCRIPTION
- Use cdn.changelog.com for the assets host
- Bump a few dependency versions

Just a tiny step towards `rc.2` 🚶

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README to simplify release version tags, adjust staged rollout percentages, rephrase release timing, and update a link in the post-release section.

* **Chores**
  * Upgraded the version of the `just` tool used in workflow configuration.
  * Updated Golang base image and Varnish Docker image digests.
  * Changed asset host references from `cdn2.changelog.com` to `cdn.changelog.com` in configuration and scripts.
  * Hardcoded a dataset value in a secrets management command for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->