### PR TITLE
Fix feeds URL rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ You are welcome to fork this and build your own - OSS FTW 💚
   - [Add troubleshooting and misc to local dev docs #29](https://github.com/thechangelog/pipely/pull/29)
 - ✅ Tag & ship `v1.0-rc.1`
 - ✅ Tag & ship `v1.0-rc.2` (component updates, etc.)
-- ☑️ Route 20% of the production traffic through
+- ✅ Route 20% of the production traffic through
+  - ✅ Fix `/feeds/<UID>` URL rewrite - [PR #31](https://github.com/thechangelog/pipely/pull/31)
 - ☑️ Tag & ship `v1.0-rc.3` (component updates, etc.)
 - ☑️ Route 50% of the production traffic through (observe cold cache behaviour, etc.)
 - ☑️ Tag & ship `v1.0` just before [changelog.com/live](https://changelog.com/live)

--- a/test/vtc/feeds.vtc
+++ b/test/vtc/feeds.vtc
@@ -265,12 +265,12 @@ server s2 {
 
   # Test for /feeds/* path
   rxreq
-  expect req.url == "/feeds/0284CC5C777C51D158BBECCBBB56422A.xml"
+  expect req.url == "/0284CC5C777C51D158BBECCBBB56422A.xml"
   txresp -status 200 -body "0284CC5C777C51D158BBECCBBB56422A.xml"
 
   # Test for /feeds/*?arg=first&arg=second path
   rxreq
-  expect req.url == "/feeds/0284CC5C777C51D158BBECCBBB56422A.xml"
+  expect req.url == "/0284CC5C777C51D158BBECCBBB56422A.xml"
   txresp -status 200 -body "0284CC5C777C51D158BBECCBBB56422A.xml"
 } -start
 
@@ -346,7 +346,7 @@ varnish v1 -vcl {
       set req.url = "/feed.xml";
     } else if (req.url ~ "^/feeds/.*(\?.*)?$") {
       set req.http.x-backend = "feeds";
-      set req.url = regsub(req.url, "^(/feeds/[^?]*)(\?.*)?$", "\1.xml");
+      set req.url = regsub(req.url, "^/feeds/([^?]*)(\?.*)?$", "/\1.xml");
     }
   }
 

--- a/varnish/vcl/default.vcl
+++ b/varnish/vcl/default.vcl
@@ -199,7 +199,7 @@ sub vcl_recv {
     set req.url = "/feed.xml";
   } else if (req.url ~ "^/feeds/.*(\?.*)?$") {
     set req.http.x-backend = "feeds";
-    set req.url = regsub(req.url, "^(/feeds/[^?]*)(\?.*)?$", "\1.xml");
+    set req.url = regsub(req.url, "^/feeds/([^?]*)(\?.*)?$", "/\1.xml");
   }
 
   ### PURGE


### PR DESCRIPTION
`/feeds/<UID>` would be rewritten to `/feeds/<UID>.xml`, which was incorrect.

We want `/<UID>.xml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated URL rewriting logic so that requests to `/feeds/<UID>` are now correctly rewritten to `/<UID>.xml` instead of `/feeds/<UID>.xml`.
  * Adjusted related test cases to match the new URL format.

* **Documentation**
  * Updated the checklist to mark the production traffic routing as complete and added a note about the `/feeds/<UID>` rewrite fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->