### PR TITLE
Increase instance size

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ You are welcome to fork this and build your own - OSS FTW 💚
 - ✅ Tag & ship `v1.0-rc.1`
 - ✅ Tag & ship `v1.0-rc.2` (component updates, etc.)
 - ✅ Route 20% of the production traffic through
-  - ✅ Fix `/feeds/<UID>` URL rewrite - [PR #31](https://github.com/thechangelog/pipely/pull/31)
+  - ✅ Fix feeds URL rewrite - [PR #31](https://github.com/thechangelog/pipely/pull/31)
+  - ✅ Increase instance size - [PR #32](https://github.com/thechangelog/pipely/pull/32)
 - ☑️ Tag & ship `v1.0-rc.3` (component updates, etc.)
 - ☑️ Route 50% of the production traffic through (observe cold cache behaviour, etc.)
 - ☑️ Tag & ship `v1.0` just before [changelog.com/live](https://changelog.com/live)

--- a/fly.toml
+++ b/fly.toml
@@ -9,11 +9,11 @@ kill_timeout = 30
 [env]
 # This leaves ~800M headroom from the machine's total available memory
 # Any less than this and Varnish makes the machine crash due to OOM errors.
-VARNISH_SIZE = "1200M"
+VARNISH_SIZE = "3200M"
 
 [[vm]]
-size = "shared-cpu-2x"
-memory = "2GB"
+size = "shared-cpu-4x"
+memory = "4GB"
 
 [deploy]
 strategy = "bluegreen"


### PR DESCRIPTION
With 20% production traffic, we are seeing peaks which are close to the 6% CPU limit. The memory got filled up fast, and we are seeing misses for the same URL, in the same datacentre. I am curious to see how a 2x instance size increase will impact this.