### PR TITLE
Better handle varnish-json-response failing on startup

### DIFF
--- a/dagger/main.go
+++ b/dagger/main.go
@@ -200,7 +200,7 @@ func (m *Pipely) app() *dagger.Container {
 app: tls-exterminator %s
 feeds: tls-exterminator %s
 assets: tls-exterminator %s
-logs: bash -c 'coproc VARNISH_JSON_RESPONSE { varnish-json-response; }; vector <&${VARNISH_JSON_RESPONSE[0]}; kill ${VARNISH_JSON_RESPONSE_PID}'
+logs: bash -c 'coproc VJS { varnish-json-response; }; if [ -z "${VJS_PID}" ]; then echo "ERROR: Failed to start varnish-json-response coprocess." >&2; exit 1; fi; trap "kill ${VJS_PID} 2>/dev/null" EXIT; vector <&${VJS[0]}'
 `, m.AppProxy.TlsExterminator, m.FeedsProxy.TlsExterminator, m.AssetsProxy.TlsExterminator)
 
 	return m.Varnish.


### PR DESCRIPTION
If varnish is slower to start, varnish-json-response can fail instantly and trigger a vector failure which results in a zombie sh process that overmind does not seem to handle well.

Until this coproc shortcut gets replaced by individual processes handled by runit, and svlog handling logs & rotation, this fix will have to do for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability and error handling for log processing, ensuring proper cleanup and clearer error messages if the logging service fails to start.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->