### PR TITLE
Increase backend timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ You are welcome to fork this and build your own - OSS FTW 💚
   - ✅ Handle varnish-json-response failing on startup - [PR #33](https://github.com/thechangelog/pipely/pull/33)
   - ✅ Bump the instance size to performance-1x with 8GB of RAM - [PR #34](https://github.com/thechangelog/pipely/pull/34)
   - Route 50% of the production traffic through
-- ☑️ Tag & ship `v1.0-rc.6`
+- ✅ Tag & ship `v1.0-rc.6`
   - ✅ Add more locations - [PR #35](https://github.com/thechangelog/pipely/pull/35)
+  - ✅ Increase backend timeout - [PR #36](https://github.com/thechangelog/pipely/pull/36)
 - ☑️ Tag & ship `v1.0`
 - ☑️ Route 100% of the production traffic through `v1.0`
 

--- a/varnish/vcl/default.vcl
+++ b/varnish/vcl/default.vcl
@@ -27,12 +27,12 @@ probe backend_health {
   # How frequently Varnish will poll the backend (in seconds)
   # Lower values provide faster detection of backend failures but increase load
   # Higher values reduce backend load but increase failure detection time
-  .interval = 5s;
+  .interval = 10s;
 
   # Maximum time to wait for a response from the backend
   # If the backend does not respond within this time, the probe is considered failed
   # Should be less than the interval to prevent probe overlap
-  .timeout = 3s;
+  .timeout = 9s;
 
   # Number of most recent probes to consider when determining backend health
   # Varnish keeps a sliding window of the latest probe results
@@ -57,27 +57,27 @@ sub vcl_init {
     ttl = 10s,
     probe = backend_health,
     host_header = std.getenv("BACKEND_APP_FQDN"),
-    first_byte_timeout = 5s,
-    connect_timeout = 5s,
-    between_bytes_timeout = 30s
+    first_byte_timeout = 10s,
+    connect_timeout = 10s,
+    between_bytes_timeout = 60s
   );
 
   new feeds = dynamic.director(
     ttl = 10s,
     probe = backend_health,
     host_header = std.getenv("BACKEND_FEEDS_FQDN"),
-    first_byte_timeout = 5s,
-    connect_timeout = 5s,
-    between_bytes_timeout = 30s
+    first_byte_timeout = 10s,
+    connect_timeout = 10s,
+    between_bytes_timeout = 60s
   );
 
   new assets = dynamic.director(
     ttl = 10s,
     probe = backend_health,
     host_header = std.getenv("BACKEND_ASSETS_FQDN"),
-    first_byte_timeout = 5s,
-    connect_timeout = 5s,
-    between_bytes_timeout = 30s
+    first_byte_timeout = 10s,
+    connect_timeout = 10s,
+    between_bytes_timeout = 60s
   );
 }
 


### PR DESCRIPTION
We've been seeing 503 responses from Varnish when backends take more than 5s to respond. Some (very few) requests are large, and they genuinely need more than 5s, so increasing the timoeut to 10s, and seeing what happens seems a reasonable change.

FTR, we've had 69 x 503 responses in the last 24h. Let's see how this improves things...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release notes to reflect the completion of the `v1.0-rc.6` release and added an entry about increased backend timeout.

* **Chores**
  * Adjusted backend health check intervals and timeouts to allow for longer response times and less frequent health checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->