### PR TITLE
Pin DNS resolution in acceptance tests

### DIFF
--- a/.github/workflows/_github.yml
+++ b/.github/workflows/_github.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: extractions/setup-just@v2
         with:
-          just-version: "1.40.0"
+          just-version: "1.43.0"
 
       - name: "Test all (including local acceptance)..."
         run: |

--- a/.github/workflows/_namespace.yml
+++ b/.github/workflows/_namespace.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: extractions/setup-just@v2
         with:
-          just-version: "1.42.3"
+          just-version: "1.43.0"
 
       - name: "Test all (including local acceptance)..."
         run: |

--- a/.github/workflows/ship_it.yml
+++ b/.github/workflows/ship_it.yml
@@ -12,8 +12,6 @@ on:
       - synchronize
       - reopened
       - ready_for_review
-  schedule:
-    - cron: "6 9 * * *"
   workflow_dispatch:
 
 # All jobs have the same outcome. We define multiple for resiliency reasons.

--- a/justfile
+++ b/justfile
@@ -50,8 +50,10 @@ test-acceptance-pipedream *ARGS:
     just op run -- \
       just hurl --test --color --report-html tmp/test-acceptance-pipedream --continue-on-error \
         --variable proto=https \
-        --variable host=pipedream.changelog.com \
+        --variable host=changelog.com \
+        --resolve changelog.com:443:137.66.2.20 \
         --variable assets_host=cdn.changelog.com \
+        --resolve cdn.changelog.com:443:137.66.2.20 \
         --variable delay_ms=65000 \
         --variable delay_s=60 \
         {{ ARGS }} \
@@ -62,7 +64,9 @@ test-acceptance-fastly *ARGS:
     @just hurl --test --color --report-html tmp/test-acceptance-fastly --continue-on-error \
       --variable proto=https \
       --variable host=changelog.com \
+      --resolve changelog.com:443:151.101.129.162 \
       --variable assets_host=cdn.changelog.com \
+      --resolve cdn.changelog.com:443:151.101.129.162 \
       {{ ARGS }} \
       test/acceptance/*.hurl test/acceptance/fastly/*.hurl
 


### PR DESCRIPTION
Shortly after https://github.com/thechangelog/changelog.com/discussions/546, when we went back to resolving 50% of the traffic to Fastly (we'll cover this in Kaizen 21), acceptance tests started failing when cdn.changelog.com & changelog.com would resolve to Pipedream.

This fixes it - we resolve DNS explicitly.

<img width="1492" height="229" alt="image" src="https://github.com/user-attachments/assets/57ef7ee6-5bfc-4f62-9f4a-8ccdea974433" />

Also, we no longer need to run acceptance tests on a schedule. We know that the setup works. We have live traffic & metrics that continuously validate the behaviour. We still run these in PRs, merges & releases, it's just the scheduled part that we are dropping.

Lastly, I lined up the local `just` version with what we are running in Namespace & GitHub.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Upgraded CI setup tooling to the latest version for improved reliability and compatibility.
  - Removed the scheduled (cron) trigger from the release workflow; it now runs on pushes, pull requests, and manual dispatch only.
- Tests
  - Updated acceptance test targets and DNS resolvers to align with new production endpoints for the site and CDN, improving test coverage and accuracy.

No user-facing features changed; behavior and public interfaces remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->