### PR TITLE
Support MP3 uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ You are welcome to fork this and build your own - OSS FTW 💚
 - ✅ Tag & ship `v1.0-rc.6`
   - ✅ Add more locations - [PR #35](https://github.com/thechangelog/pipely/pull/35)
   - ✅ Increase backend timeout - [PR #36](https://github.com/thechangelog/pipely/pull/36)
-- ☑️ Tag & ship `v1.0-rc.7`
+- ✅ Tag & ship `v1.0-rc.7`
   - ✅ Update to Varnish v7.7.3 & Vector v0.49.0 - [PR #38](https://github.com/thechangelog/pipely/pull/38)
-  - ☑️ Support mp3 uploads
+  - ✅ Support MP3 uploads - [PR #39](https://github.com/thechangelog/pipely/pull/39)
 - ☑️ Tag & ship `v1.0-rc.8`
   - ☑️ Replace overmind with runit
 - ☑️ Tag & ship `v1.0`

--- a/just/_config.just
+++ b/just/_config.just
@@ -39,6 +39,9 @@ FLY_APP_REGIONS := env("FLY_APP_REGIONS", "sea,sjc,lax,dfw,ord,iad,ewr,scl,lhr,c
 [private]
 export PURGE_TOKEN := env("PURGE_TOKEN", "local-purge")
 
+[private]
+LOCAL_CONTAINER_IMAGE := env("LOCAL_CONTAINER_IMAGE", "pipely.dev:" + datetime("%Y-%m-%d"))
+
 # https://linux.101hacks.com/ps1-examples/prompt-color-using-tput/
 
 [private]

--- a/varnish/vcl/default.vcl
+++ b/varnish/vcl/default.vcl
@@ -57,7 +57,8 @@ sub vcl_init {
     ttl = 10s,
     probe = backend_health,
     host_header = std.getenv("BACKEND_APP_FQDN"),
-    first_byte_timeout = 10s,
+    # Increase first_byte_timeout so that mp3 uploads work
+    first_byte_timeout = 300s,
     connect_timeout = 10s,
     between_bytes_timeout = 60s
   );


### PR DESCRIPTION
This increases the app first_byte_timeout to 5 minutes so that Varnish has enough time to upload the file to the app, and receive a response in a timely fashion.

I tested with a 212MB file which took 22s to upload to Varnish, and another 54s for the backend to process it. While I could set the first_byte_timeout to a lower value (e.g. 180s), the 300s values gives plenty of headroom in case one of the components in the chain is slower than normal.

As I was testing this out, I had to change the way the container was running locally because requests kept timing out during admin logins 🤷‍♂️

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Increased backend response timeout to reduce 504 errors on long-running requests.

- Chores
  - Added a docker-run command for easier local container build/run workflows.
  - Introduced a private local container image setting for streamlined development.

- Documentation
  - Updated README changelog wording and added a PR reference for MP3 uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->